### PR TITLE
Add support to allow multiple deletes together

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -427,14 +427,14 @@ Use case ends.
 
 ---
 
-**Use case: Delete a location**
+**Use case: Delete one or more locations**
 
 **MSS**
 
 1. User requests to list locations.
 2. AddressMe shows a list of locations.
-3. User requests to delete a specific location.
-4. AddressMe deletes the location.
+3. User requests to delete one or more locations.
+4. AddressMe deletes all specified locations.
 Use case ends.
 
 **Extensions**
@@ -444,14 +444,20 @@ Use case ends.
 Use case ends.
 
 
-* 3a. The given index is invalid.
+* 3a. At least one given index is invalid.
 * 3a1. AddressMe shows an error message.
 * 3a2. AddressMe lists the available locations again.
 Use case resumes at step 2.
 
 
-* 4a. An error occurs during deletion.
-* 4a1. AddressMe informs the user that the deletion failed.
+* 3b. Duplicate indices are provided (e.g., `delete 2 2`).
+* 3b1. AddressMe shows an error message.
+* 3b2. AddressMe lists the available locations again.
+Use case resumes at step 2.
+
+
+* 5a. An error occurs during deletion.
+* 5a1. AddressMe informs the user that the deletion failed.
 Use case ends.
 
 
@@ -516,10 +522,13 @@ testers are expected to do more *exploratory* testing.
    1. Test case: `delete 1`<br>
       Expected: First contact is deleted from the list. Details of the deleted contact shown in the status message. Timestamp in the status bar is updated.
 
+   1. Test case: `delete 1 2`<br>
+      Expected: First and second contacts are deleted from the list. Number of deleted locations shown in the status message. Timestamp in the status bar is updated.
+
    1. Test case: `delete 0`<br>
       Expected: No location is deleted. Error details shown in the status message. Status bar remains the same.
 
-   1. Other incorrect delete commands to try: `delete`, `delete x`, `...` (where x is larger than the list size)<br>
+   1. Other incorrect delete commands to try: `delete`, `delete x`, `delete 1 1`, `...` (where x is larger than the list size)<br>
       Expected: Similar to previous.
 
 1. _{ more test cases …​ }_

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -130,17 +130,19 @@ Examples:
 
 ### Deleting a location : `delete`
 
-Deletes the specified location from the address book.
+Deletes one or more specified locations from the address book.
 
-Format: `delete INDEX`
+Format: `delete INDEX [MORE_INDEXES]...`
 
-* Deletes the location at the specified `INDEX`.
-* The index refers to the index number shown in the displayed location list.
-* The index **must be a positive integer** 1, 2, 3, …​
+* Deletes the locations at the specified `INDEX` values.
+* The indices refer to the index numbers shown in the displayed location list.
+* Every index **must be a positive integer** 1, 2, 3, …​
+* Duplicate indices are not allowed.
 
 Examples:
 * `list` followed by `delete 2` deletes the 2nd location in the address book.
-* `find Betsy` followed by `delete 1` deletes the 1st location in the results of the `find` command.
+* `find Sentosa` followed by `delete 1` deletes the 1st location in the results of the `find` command.
+* `list` followed by `delete 1 3 5` deletes the 1st, 3rd, and 5th locations in the address book.
 
 ### Clearing all entries : `clear`
 
@@ -193,7 +195,7 @@ Action | Format, Examples
 --------|------------------
 **Add** | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague`
 **Clear** | `clear`
-**Delete** | `delete INDEX`<br> e.g., `delete 3`
+**Delete** | `delete INDEX [MORE_INDEXES]...`<br> e.g., `delete 3` or `delete 1 2 3`
 **Edit** | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
 **Find** | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
 **List** | `list`

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -2,7 +2,11 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
@@ -19,30 +23,56 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the location identified by the index number used in the displayed location list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + ": Deletes the location(s) identified by the index number(s) used in the displayed location list.\n"
+            + "Parameters: INDEX [MORE_INDEXES]... (indices must be positive integers)\n"
+            + "Example: " + COMMAND_WORD + " 1 2 3";
 
     public static final String MESSAGE_DELETE_LOCATION_SUCCESS = "Deleted Location: %1$s";
+    public static final String MESSAGE_DELETE_LOCATIONS_SUCCESS = "Deleted Locations:\n%1$s";
+    public static final String MESSAGE_DUPLICATE_INDEX = "Duplicate indices are not allowed.";
 
-    private final Index targetIndex;
+    private final List<Index> targetIndexes;
 
-    public DeleteCommand(Index targetIndex) {
-        this.targetIndex = targetIndex;
+    public DeleteCommand(List<Index> targetIndexes) {
+        requireNonNull(targetIndexes);
+        if (targetIndexes.isEmpty()) {
+            throw new IllegalArgumentException("At least one index must be provided.");
+        }
+        this.targetIndexes = List.copyOf(targetIndexes);
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Location> lastShownList = model.getFilteredLocationList();
+        Set<Integer> uniqueIndexes = new HashSet<>();
+        List<Location> locationsToDelete = new ArrayList<>();
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_LOCATION_DISPLAYED_INDEX);
+        for (Index targetIndex : targetIndexes) {
+            if (!uniqueIndexes.add(targetIndex.getZeroBased())) {
+                throw new CommandException(MESSAGE_DUPLICATE_INDEX);
+            }
+
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_LOCATION_DISPLAYED_INDEX);
+            }
+
+            locationsToDelete.add(lastShownList.get(targetIndex.getZeroBased()));
         }
 
-        Location locationToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deleteLocation(locationToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_LOCATION_SUCCESS, Messages.format(locationToDelete)));
+        for (Location locationToDelete : locationsToDelete) {
+            model.deleteLocation(locationToDelete);
+        }
+
+        if (locationsToDelete.size() == 1) {
+            return new CommandResult(String.format(MESSAGE_DELETE_LOCATION_SUCCESS,
+                    Messages.format(locationsToDelete.get(0))));
+        }
+
+        String deletedLocations = locationsToDelete.stream()
+                .map(Messages::format)
+                .collect(Collectors.joining("\n"));
+        return new CommandResult(String.format(MESSAGE_DELETE_LOCATIONS_SUCCESS, deletedLocations));
     }
 
     @Override
@@ -57,13 +87,13 @@ public class DeleteCommand extends Command {
         }
 
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-        return targetIndex.equals(otherDeleteCommand.targetIndex);
+        return targetIndexes.equals(otherDeleteCommand.targetIndexes);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("targetIndex", targetIndex)
+                .add("targetIndexes", targetIndexes)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -33,6 +33,13 @@ public class DeleteCommand extends Command {
 
     private final List<Index> targetIndexes;
 
+    /**
+     * Creates a {@code DeleteCommand} to delete the locations at the specified indices.
+     *
+     * @param targetIndexes A non-empty list of indices to delete.
+     * @throws NullPointerException if {@code targetIndexes} is null.
+     * @throws IllegalArgumentException if {@code targetIndexes} is empty.
+     */
     public DeleteCommand(List<Index> targetIndexes) {
         requireNonNull(targetIndexes);
         if (targetIndexes.isEmpty()) {

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -2,6 +2,9 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -18,8 +21,15 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            String trimmedArgs = args.trim();
+            String[] indexTokens = trimmedArgs.split("\\s+");
+
+            List<Index> indexes = new ArrayList<>();
+            for (String indexToken : indexTokens) {
+                indexes.add(ParserUtil.parseIndex(indexToken));
+            }
+
+            return new DeleteCommand(indexes);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -8,7 +8,10 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showLocationAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_LOCATION;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_LOCATION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_LOCATION;
 import static seedu.address.testutil.TypicalLocations.getTypicalAddressBook;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +33,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Location locationToDelete = model.getFilteredLocationList().get(INDEX_FIRST_LOCATION.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_LOCATION);
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(INDEX_FIRST_LOCATION));
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_LOCATION_SUCCESS,
                 Messages.format(locationToDelete));
@@ -44,9 +47,31 @@ public class DeleteCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredLocationList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(outOfBoundIndex));
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_LOCATION_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexesUnfilteredList_success() {
+        Location firstLocationToDelete = model.getFilteredLocationList().get(INDEX_FIRST_LOCATION.getZeroBased());
+        Location thirdLocationToDelete = model.getFilteredLocationList().get(INDEX_THIRD_LOCATION.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(INDEX_FIRST_LOCATION, INDEX_THIRD_LOCATION));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteLocation(firstLocationToDelete);
+        expectedModel.deleteLocation(thirdLocationToDelete);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_LOCATIONS_SUCCESS,
+                Messages.format(firstLocationToDelete) + "\n" + Messages.format(thirdLocationToDelete));
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicateIndexes_throwsCommandException() {
+        DeleteCommand deleteCommand = new DeleteCommand(
+                List.of(INDEX_FIRST_LOCATION, INDEX_FIRST_LOCATION));
+        assertCommandFailure(deleteCommand, model, DeleteCommand.MESSAGE_DUPLICATE_INDEX);
     }
 
     @Test
@@ -54,7 +79,7 @@ public class DeleteCommandTest {
         showLocationAtIndex(model, INDEX_FIRST_LOCATION);
 
         Location locationToDelete = model.getFilteredLocationList().get(INDEX_FIRST_LOCATION.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_LOCATION);
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(INDEX_FIRST_LOCATION));
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_LOCATION_SUCCESS,
                 Messages.format(locationToDelete));
@@ -74,21 +99,21 @@ public class DeleteCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getLocationList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(outOfBoundIndex));
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_LOCATION_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_LOCATION);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_LOCATION);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(List.of(INDEX_FIRST_LOCATION));
+        DeleteCommand deleteSecondCommand = new DeleteCommand(List.of(INDEX_SECOND_LOCATION));
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_LOCATION);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(List.of(INDEX_FIRST_LOCATION));
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false
@@ -104,8 +129,8 @@ public class DeleteCommandTest {
     @Test
     public void toStringMethod() {
         Index targetIndex = Index.fromOneBased(1);
-        DeleteCommand deleteCommand = new DeleteCommand(targetIndex);
-        String expected = DeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(targetIndex));
+        String expected = DeleteCommand.class.getCanonicalName() + "{targetIndexes=[" + targetIndex + "]}";
         assertEquals(expected, deleteCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_LOCATION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_LOCATION;
 
 import java.util.Arrays;
 import java.util.List;
@@ -50,7 +51,13 @@ public class AddressBookParserTest {
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_LOCATION.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_LOCATION), command);
+        assertEquals(new DeleteCommand(List.of(INDEX_FIRST_LOCATION)), command);
+
+        DeleteCommand multipleCommand = (DeleteCommand) parser.parseCommand(
+                DeleteCommand.COMMAND_WORD + " "
+                        + INDEX_FIRST_LOCATION.getOneBased() + " "
+                        + INDEX_SECOND_LOCATION.getOneBased());
+        assertEquals(new DeleteCommand(List.of(INDEX_FIRST_LOCATION, INDEX_SECOND_LOCATION)), multipleCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -4,6 +4,9 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_LOCATION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_LOCATION;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,11 +25,18 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_LOCATION));
+        assertParseSuccess(parser, "1", new DeleteCommand(List.of(INDEX_FIRST_LOCATION)));
+    }
+
+    @Test
+    public void parse_validMultipleArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, "1 2",
+                new DeleteCommand(List.of(INDEX_FIRST_LOCATION, INDEX_SECOND_LOCATION)));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "  ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
## Description

This PR enhances the `delete` command by adding support for deleting multiple locations in a single command. Users can now specify multiple indices separated by spaces, and all corresponding entries will be removed in one execution.

For example:
- `delete 1 2 3` deletes the 1st, 2nd, and 3rd displayed locations
- `delete 5 7` deletes the 5th and 7th locations in the current list

This improvement increases efficiency for users managing many destinations, reducing the need to repeatedly invoke the `delete` command.

The command strictly validates input to prevent:
- ❌ Duplicate indices (e.g. `delete 1 1 1`)
- ❌ Invalid indices (e.g. out-of-range or non-numeric values)
- ❌ Empty input after `delete`

This ensures predictable and safe batch deletion behavior.

---

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

---

## Test Coverage

- ✅ **Unit Tests:** Tests for duplicate index detection and invalid input handling  
- ✅ **Component Tests:** Tests for correct deletion of multiple locations  
- ✅ **Integration Tests:** Updated `DeleteCommandTest` and `DeleteCommandParserTest`  
- ✅ **All existing tests pass**

### Manual Testing Verification

- `delete 1 2 3` → Deletes the corresponding 3 locations  
- `delete 3 1` → Deletes both entries regardless of order  
- `delete 1 1` → Shows duplicate index error message  
- `delete 999` → Shows invalid index error message  
- `delete a` → Shows invalid format error  
- `delete` → Shows usage message  

---

## Related Issues

Closes #49 

---

## Checklist for Reviewers

- [ ] Code follows the project's coding style  
- [ ] Comments and documentation are clear and accurate  
- [ ] All tests pass locally  
- [ ] New tests added for new functionality  
- [ ] No breaking changes introduced  
- [ ] User documentation updated with multi-delete examples  
- [ ] Developer documentation updated with parsing and validation logic  
- [ ] Edge cases handled (duplicate indices, invalid numbers, empty input)  
- [ ] Merge conflicts resolved correctly with Location model  

---

## Future Enhancements

Possible improvements for future iterations:

- Add optional confirmation mode for bulk deletes (e.g. `delete 1 2 3 --confirm`)
- Add range support (e.g. `delete 1-5`)
- Support attribute-based deletion (e.g. `delete c/Japan`, `delete d/2026-03-15`)
- Allow combined filters for deletion (e.g. `delete c/Japan d/2026-03-15`)