### PR TITLE
Improve Help Command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -23,7 +23,7 @@ AddressMe is a **desktop app for managing destinations, optimized for use via a 
    A GUI similar to the below should appear in a few seconds. Note how the app contains some sample data.<br>
    ![Ui](images/Ui.png)
 
-1. Type the command in the command box and press Enter to execute it. e.g. typing **`help`** and pressing Enter will open the help window.<br>
+1. Type the command in the command box and press Enter to execute it. e.g. typing **`help`** and pressing Enter will show the local help overview.<br>
    Some example commands you can try:
 
    * `list` : Lists all contacts.
@@ -58,8 +58,8 @@ AddressMe is a **desktop app for managing destinations, optimized for use via a 
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 
-* Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
-  e.g. if the command specifies `help 123`, it will be interpreted as `help`.
+* Extraneous parameters for commands that do not take in parameters (such as `list`, `exit` and `clear`) will be ignored.<br>
+  e.g. if the command specifies `list 123`, it will be interpreted as `list`.
 
 * Date fields support the formats: `yyyy/M/d`, `d/M/yyyy`, `d/M/yy` as well as hyphenated variants.
 E.g. 2 Jan 2026 can be typed as `2026/01/02`, `2/1/26`, `2026-1-02`, `02-1-2026`.
@@ -73,11 +73,22 @@ E.g. If today was Tuesday, `Tue` would be today, `Wednesday` would be tomorrow, 
 
 ### Viewing help : `help`
 
-Shows a message explaining how to access the help page.
+Shows the local help overview, command-specific help, or opens the online User Guide.
 
-![help message](images/helpMessage.png)
+Format:
+```
+help
+help COMMAND_WORD
+help -ug
+```
 
-Format: `help`
+* `help` displays a summary of all supported commands in the CLI.
+* `help COMMAND_WORD` displays detailed local guidance for that command.
+* `help -ug` opens the help window for the online User Guide.
+* `COMMAND_WORD` must be an existing built-in command word.
+
+Examples:
+* `help add` shows the local guidance for the `add` command.
 
 
 ### Adding a location: `add`
@@ -267,5 +278,5 @@ Action | Format, Examples
 **Edit** | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [d/DATE]… [d+/DATE]… [d-/DATE]… [t/TAG]… [t+/TAG]… [t-/TAG]…`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com d+/2026-02-01`
 **Find** | `find [KEYWORD] [MORE_KEYWORDS] [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]… [d/DATE]…`<br> e.g., `find n/Cafe t/Halal d/2026-01-01`
 **List** | `list`
-**Help** | `help`
+**Help** | `help` / `help COMMAND_WORD` / `help -ug`<br> e.g., `help`, `help add`, `help -ug`
 **Shortcut** | `shortcut set ALIAS COMMAND_WORD` / `shortcut remove ALIAS` / `shortcut list`<br> e.g., `shortcut set a add`, `shortcut remove a`, `shortcut list`

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -22,7 +22,7 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a location to AddressMe. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a location to AddressMe.\n"
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + "[" + PREFIX_PHONE + "PHONE] "

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -11,6 +11,8 @@ import seedu.address.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Clears all saved locations.\n"
+            + "Example: " + COMMAND_WORD;
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
 
 

--- a/src/main/java/seedu/address/logic/commands/CommandDatabase.java
+++ b/src/main/java/seedu/address/logic/commands/CommandDatabase.java
@@ -15,7 +15,7 @@ import java.util.Set;
 public class CommandDatabase {
 
     private static final String OVERVIEW_INTRO = "Available commands:";
-    private static final String OVERVIEW_FOOTER = "Use `help <command>` for detailed guidance.";
+    private static final String OVERVIEW_FOOTER = "Use `help COMMAND_WORD` for detailed guidance.";
 
     private final Map<String, CommandInfo> commandRegistry;
 

--- a/src/main/java/seedu/address/logic/commands/CommandDatabase.java
+++ b/src/main/java/seedu/address/logic/commands/CommandDatabase.java
@@ -2,49 +2,53 @@ package seedu.address.logic.commands;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
  * Represents the collection of command keywords available to the user
- * and maps potential user shortcuts to the raw commands
+ * and stores help metadata for built-in commands.
  */
 public class CommandDatabase {
 
-    private final List<String> commands;
+    private static final String OVERVIEW_INTRO = "Available commands:";
+    private static final String OVERVIEW_FOOTER = "Use `help <command>` for detailed guidance.";
+
+    private final Map<String, CommandInfo> commandRegistry;
 
     /**
-     * Initializes the database with the command keywords
+     * Initializes the database with the command keywords.
      */
     public CommandDatabase() {
-        // can later be substituted as loading a command txt file
-        commands = List.of(
-                AddCommand.COMMAND_WORD,
-                ClearCommand.COMMAND_WORD,
-                DeleteCommand.COMMAND_WORD,
-                EditCommand.COMMAND_WORD,
-                ExitCommand.COMMAND_WORD,
-                FindCommand.COMMAND_WORD,
-                HelpCommand.COMMAND_WORD,
-                ListCommand.COMMAND_WORD,
-                PlanCommand.COMMAND_WORD,
-                ShortcutCommand.COMMAND_WORD);
+        commandRegistry = new LinkedHashMap<>();
+        register(AddCommand.COMMAND_WORD, "Add a new location to AddressMe.", AddCommand.MESSAGE_USAGE);
+        register(ClearCommand.COMMAND_WORD, "Remove all saved locations.", ClearCommand.MESSAGE_USAGE);
+        register(DeleteCommand.COMMAND_WORD, "Delete one or more locations by index.", DeleteCommand.MESSAGE_USAGE);
+        register(EditCommand.COMMAND_WORD, "Edit an existing location.", EditCommand.MESSAGE_USAGE);
+        register(ExitCommand.COMMAND_WORD, "Exit the application.", ExitCommand.MESSAGE_USAGE);
+        register(FindCommand.COMMAND_WORD, "Find locations matching your search criteria.", FindCommand.MESSAGE_USAGE);
+        register(HelpCommand.COMMAND_WORD, "Show help overview or details for a command.",
+                HelpCommand.MESSAGE_USAGE);
+        register(ListCommand.COMMAND_WORD, "List all saved locations.", ListCommand.MESSAGE_USAGE);
+        register(PlanCommand.COMMAND_WORD, "Show or clear the planner for a specific date.", PlanCommand.MESSAGE_USAGE);
+        register(ShortcutCommand.COMMAND_WORD, "Manage command shortcuts.", ShortcutCommand.MESSAGE_USAGE);
     }
 
     /**
-     * Autocompletes the given input into an existing command
-     * @param prefix
-     * @return
+     * Autocompletes the given input into an existing command.
      */
     public String completePrefix(String prefix) {
         List<String> matches = new ArrayList<>();
 
-        for (String cmd : commands) {
+        for (String cmd : commandRegistry.keySet()) {
             if (cmd.startsWith(prefix.toLowerCase())) {
                 matches.add(cmd);
             }
         }
-        //
+
         if (matches.isEmpty()) {
             return prefix;
         }
@@ -60,20 +64,55 @@ public class CommandDatabase {
      * Returns true if {@code commandWord} is a known command word.
      */
     public boolean isKnownCommand(String commandWord) {
-        return commands.contains(commandWord.toLowerCase());
+        return commandRegistry.containsKey(commandWord.toLowerCase());
     }
 
     /**
      * Returns the known command words.
      */
     public Set<String> getCommandWords() {
-        return Set.copyOf(commands);
+        return Set.copyOf(commandRegistry.keySet());
     }
 
     /**
-     * Finds the longest common prefix of a list of words
-     * @param words a list of at least 2 Strings
-     * @return the longest common prefix of all the Strings passed in
+     * Returns the help overview text for all built-in commands.
+     */
+    public String getHelpOverview() {
+        StringBuilder builder = new StringBuilder(OVERVIEW_INTRO);
+        commandRegistry.values().forEach(commandInfo -> builder.append("\n")
+                .append(commandInfo.commandWord())
+                .append(": ")
+                .append(commandInfo.summary()));
+        builder.append("\n\n").append(OVERVIEW_FOOTER);
+        return builder.toString();
+    }
+
+    /**
+     * Returns detailed help text for the given command word, if known.
+     */
+    public Optional<String> getDetailedHelp(String commandWord) {
+        if (commandWord == null) {
+            return Optional.empty();
+        }
+
+        CommandInfo commandInfo = commandRegistry.get(commandWord.toLowerCase());
+        if (commandInfo == null) {
+            return Optional.empty();
+        }
+
+        // return Optional.of(commandInfo.summary() + "\n\n" + commandInfo.usage());
+         return Optional.of(commandInfo.usage());
+    }
+
+    private void register(String commandWord, String summary, String usage) {
+        commandRegistry.put(commandWord, new CommandInfo(commandWord, summary, usage));
+    }
+
+    /**
+     * Finds the longest common prefix of a list of words.
+     *
+     * @param words a list of at least 2 strings
+     * @return the longest common prefix of all the strings passed in
      */
     private String longestCommonPrefix(List<String> words) {
         String min = Collections.min(words);
@@ -87,4 +126,6 @@ public class CommandDatabase {
 
         return min.substring(0, i);
     }
+
+    private record CommandInfo(String commandWord, String summary, String usage) { }
 }

--- a/src/main/java/seedu/address/logic/commands/CommandDatabase.java
+++ b/src/main/java/seedu/address/logic/commands/CommandDatabase.java
@@ -101,7 +101,7 @@ public class CommandDatabase {
         }
 
         // return Optional.of(commandInfo.summary() + "\n\n" + commandInfo.usage());
-         return Optional.of(commandInfo.usage());
+        return Optional.of(commandInfo.usage());
     }
 
     private void register(String commandWord, String summary, String usage) {

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -8,6 +8,8 @@ import seedu.address.model.Model;
 public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exits the application.\n"
+            + "Example: " + COMMAND_WORD;
 
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
 

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -12,13 +12,14 @@ import seedu.address.model.Model;
  * Formats help instructions for local display and optionally opens the help window.
  */
 public class HelpCommand extends Command {
-
+    public static final String LINK_FLAG = "-ug";
     public static final String COMMAND_WORD = "help";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows a summary of all commands, or help for a "
-            + "specific command.\n"
-            + "Parameters: [COMMAND_WORD]\n"
-            + "Example: " + COMMAND_WORD + " add";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows a summary of all commands, help for a "
+            + "specific command, or opens the online user guide.\n"
+            + "Parameters: [COMMAND_WORD] | [" + LINK_FLAG + "]\n"
+            + "Example: " + COMMAND_WORD + " add\n"
+            + "Example: " + COMMAND_WORD + " " + LINK_FLAG;
 
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
     public static final String MESSAGE_UNKNOWN_HELP_TOPIC = "Unknown command for help: %1$s";
@@ -26,27 +27,44 @@ public class HelpCommand extends Command {
     private static final CommandDatabase COMMAND_DATABASE = new CommandDatabase();
 
     private final String targetCommand;
+    private final boolean shouldShowLink;
 
     /**
      * Creates a help command for the overview.
      */
     public HelpCommand() {
-        this(null);
+        this(null, false);
+    }
+
+    /**
+     * Creates a help command that opens the online help window.
+     */
+    public HelpCommand(boolean shouldShowLink) {
+        this(null, shouldShowLink);
     }
 
     /**
      * Creates a help command for the specified command word.
      */
     public HelpCommand(String targetCommand) {
+        this(targetCommand, false);
+    }
+
+    private HelpCommand(String targetCommand, boolean shouldShowLink) {
         this.targetCommand = targetCommand;
+        this.shouldShowLink = shouldShowLink;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
+        if (shouldShowLink) {
+            return new CommandResult(SHOWING_HELP_MESSAGE, null, true, false);
+        }
+
         if (targetCommand == null) {
-            return new CommandResult(COMMAND_DATABASE.getHelpOverview(), null, true, false);
+            return new CommandResult(COMMAND_DATABASE.getHelpOverview());
         }
 
         return COMMAND_DATABASE.getDetailedHelp(targetCommand)
@@ -65,13 +83,15 @@ public class HelpCommand extends Command {
         }
 
         HelpCommand otherHelpCommand = (HelpCommand) other;
-        return Objects.equals(targetCommand, otherHelpCommand.targetCommand);
+        return Objects.equals(targetCommand, otherHelpCommand.targetCommand)
+                && shouldShowLink == otherHelpCommand.shouldShowLink;
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .add("targetCommand", targetCommand)
+                .add("shouldShowLink", shouldShowLink)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -1,21 +1,77 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.Objects;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
 /**
- * Format full help instructions for every command for display.
+ * Formats help instructions for local display and optionally opens the help window.
  */
 public class HelpCommand extends Command {
 
     public static final String COMMAND_WORD = "help";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
-            + "Example: " + COMMAND_WORD;
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows a summary of all commands, or help for a "
+            + "specific command.\n"
+            + "Parameters: [COMMAND_WORD]\n"
+            + "Example: " + COMMAND_WORD + " add";
 
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
+    public static final String MESSAGE_UNKNOWN_HELP_TOPIC = "Unknown command for help: %1$s";
+
+    private static final CommandDatabase COMMAND_DATABASE = new CommandDatabase();
+
+    private final String targetCommand;
+
+    /**
+     * Creates a help command for the overview.
+     */
+    public HelpCommand() {
+        this(null);
+    }
+
+    /**
+     * Creates a help command for the specified command word.
+     */
+    public HelpCommand(String targetCommand) {
+        this.targetCommand = targetCommand;
+    }
 
     @Override
-    public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, null, true, false);
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (targetCommand == null) {
+            return new CommandResult(COMMAND_DATABASE.getHelpOverview(), null, true, false);
+        }
+
+        return COMMAND_DATABASE.getDetailedHelp(targetCommand)
+                .map(CommandResult::new)
+                .orElseThrow(() -> new CommandException(String.format(MESSAGE_UNKNOWN_HELP_TOPIC, targetCommand)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof HelpCommand)) {
+            return false;
+        }
+
+        HelpCommand otherHelpCommand = (HelpCommand) other;
+        return Objects.equals(targetCommand, otherHelpCommand.targetCommand);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetCommand", targetCommand)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -11,6 +11,8 @@ import seedu.address.model.Model;
 public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all saved locations.\n"
+            + "Example: " + COMMAND_WORD;
 
     public static final String MESSAGE_SUCCESS = "Listed all locations";
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -80,7 +80,7 @@ public class AddressBookParser {
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+            return new HelpCommandParser().parse(arguments);
 
         case ShortcutCommand.COMMAND_WORD:
             return new ShortcutCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.CommandDatabase;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new {@code HelpCommand} object.
+ */
+public class HelpCommandParser implements Parser<HelpCommand> {
+
+    private final CommandDatabase commandDatabase = new CommandDatabase();
+
+    @Override
+    public HelpCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            return new HelpCommand();
+        }
+
+        String[] tokens = trimmedArgs.split("\\s+");
+        if (tokens.length != 1) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
+        String commandWord = tokens[0].toLowerCase();
+        if (!commandDatabase.isKnownCommand(commandWord)) {
+            throw new ParseException(String.format(HelpCommand.MESSAGE_UNKNOWN_HELP_TOPIC, tokens[0]));
+        }
+
+        return new HelpCommand(commandWord);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
@@ -25,6 +25,10 @@ public class HelpCommandParser implements Parser<HelpCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
+        if (HelpCommand.LINK_FLAG.equals(tokens[0])) {
+            return new HelpCommand(true);
+        }
+
         String commandWord = tokens[0].toLowerCase();
         if (!commandDatabase.isKnownCommand(commandWord)) {
             throw new ParseException(String.format(HelpCommand.MESSAGE_UNKNOWN_HELP_TOPIC, tokens[0]));

--- a/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import seedu.address.logic.commands.CommandDatabase;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -10,8 +9,6 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new {@code HelpCommand} object.
  */
 public class HelpCommandParser implements Parser<HelpCommand> {
-
-    private final CommandDatabase commandDatabase = new CommandDatabase();
 
     @Override
     public HelpCommand parse(String args) throws ParseException {
@@ -30,10 +27,6 @@ public class HelpCommandParser implements Parser<HelpCommand> {
         }
 
         String commandWord = tokens[0].toLowerCase();
-        if (!commandDatabase.isKnownCommand(commandWord)) {
-            throw new ParseException(String.format(HelpCommand.MESSAGE_UNKNOWN_HELP_TOPIC, tokens[0]));
-        }
-
         return new HelpCommand(commandWord);
     }
 }

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -15,7 +15,7 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
+    public static final String USERGUIDE_URL = "https://AY2526S2-CS2103T-W14-3.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);

--- a/src/test/java/seedu/address/logic/commands/CommandDatabaseTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandDatabaseTest.java
@@ -78,7 +78,7 @@ public class CommandDatabaseTest {
         assertTrue(helpOverview.startsWith("Available commands:"));
         commandDatabase.getCommandWords().forEach(commandWord ->
                 assertTrue(helpOverview.contains(commandWord + ":")));
-        assertTrue(helpOverview.contains("help <command>"));
+        assertTrue(helpOverview.contains("help COMMAND_WORD"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandDatabaseTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandDatabaseTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,5 +69,21 @@ public class CommandDatabaseTest {
     @Test
     void testCaseSensitivity() {
         assertEquals("add", commandDatabase.completePrefix("Add"));
+    }
+
+    @Test
+    void getHelpOverview_containsCommandsAndFooter() {
+        String helpOverview = commandDatabase.getHelpOverview();
+
+        assertTrue(helpOverview.startsWith("Available commands:"));
+        commandDatabase.getCommandWords().forEach(commandWord ->
+                assertTrue(helpOverview.contains(commandWord + ":")));
+        assertTrue(helpOverview.contains("help <command>"));
+    }
+
+    @Test
+    void getDetailedHelp_knownCommand_returnsUsage() {
+        assertEquals(AddCommand.MESSAGE_USAGE,
+                commandDatabase.getDetailedHelp(AddCommand.COMMAND_WORD).orElseThrow());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.HelpCommand.SHOWING_HELP_MESSAGE;
 
 import org.junit.jupiter.api.Test;
 
@@ -9,12 +9,25 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 
 public class HelpCommandTest {
-    private Model model = new ModelManager();
-    private Model expectedModel = new ModelManager();
+    private final Model model = new ModelManager();
+    private final Model expectedModel = new ModelManager();
+    private final CommandDatabase commandDatabase = new CommandDatabase();
 
     @Test
-    public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, null, true, false);
+    public void execute_overview_success() {
+        CommandResult expectedCommandResult = new CommandResult(commandDatabase.getHelpOverview(), null, true, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_contextualHelp_success() {
+        String expectedMessage = commandDatabase.getDetailedHelp(AddCommand.COMMAND_WORD).orElseThrow();
+        assertCommandSuccess(new HelpCommand(AddCommand.COMMAND_WORD), model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_unknownCommand_failure() {
+        assertCommandFailure(new HelpCommand("unknown"), model,
+                String.format(HelpCommand.MESSAGE_UNKNOWN_HELP_TOPIC, "unknown"));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -15,8 +15,14 @@ public class HelpCommandTest {
 
     @Test
     public void execute_overview_success() {
-        CommandResult expectedCommandResult = new CommandResult(commandDatabase.getHelpOverview(), null, true, false);
+        CommandResult expectedCommandResult = new CommandResult(commandDatabase.getHelpOverview());
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_link_success() {
+        CommandResult expectedCommandResult = new CommandResult(HelpCommand.SHOWING_HELP_MESSAGE, null, true, false);
+        assertCommandSuccess(new HelpCommand(true), model, expectedCommandResult, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -1,4 +1,3 @@
-/*
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,12 +38,14 @@ public class AddressBookParserTest {
 
     private final AddressBookParser parser = new AddressBookParser();
 
+    /*
     @Test
     public void parseCommand_add() throws Exception {
         Location location = new LocationBuilder().build();
         AddCommand command = (AddCommand) parser.parseCommand(LocationUtil.getAddCommand(location));
         assertEquals(new AddCommand(location), command);
     }
+     */
 
     @Test
     public void parseCommand_clear() throws Exception {
@@ -65,6 +66,7 @@ public class AddressBookParserTest {
         assertEquals(new DeleteCommand(List.of(INDEX_FIRST_LOCATION, INDEX_SECOND_LOCATION)), multipleCommand);
     }
 
+    /*
     @Test
     public void parseCommand_edit() throws Exception {
         Location location = new LocationBuilder().build();
@@ -73,6 +75,7 @@ public class AddressBookParserTest {
                 + INDEX_FIRST_LOCATION.getOneBased() + " " + LocationUtil.getEditLocationDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_LOCATION, descriptor), command);
     }
+     */
 
     @Test
     public void parseCommand_exit() throws Exception {
@@ -95,10 +98,28 @@ public class AddressBookParserTest {
         assertTrue(parser.parseCommand(PlanCommand.COMMAND_WORD + " 2/3/12") instanceof PlanCommand);
     }
 
+    /*
     @Test
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+    }
+     */
+
+    @Test
+    public void parseCommand_helpOverview_success() throws Exception {
+        assertEquals(new HelpCommand(), parser.parseCommand("help"));
+    }
+
+    @Test
+    public void parseCommand_helpContextual_success() throws Exception {
+        assertEquals(new HelpCommand("add"), parser.parseCommand("help add"));
+    }
+
+    @Test
+    public void parseCommand_helpMalformed_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE),
+                () -> parser.parseCommand("help add extra"));
     }
 
     @Test
@@ -124,4 +145,3 @@ public class AddressBookParserTest {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
     }
 }
-*/

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -114,6 +114,11 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_helpLink_success() throws Exception {
+        assertEquals(new HelpCommand(true), parser.parseCommand("help " + HelpCommand.LINK_FLAG));
+    }
+
+    @Test
     public void parseCommand_helpMalformed_throwsParseException() {
         assertThrows(ParseException.class,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -15,11 +15,11 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.AddCommand;
+// import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditCommand.EditLocationDescriptor;
+// import seedu.address.logic.commands.EditCommand;
+// import seedu.address.logic.commands.EditCommand.EditLocationDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -28,11 +28,11 @@ import seedu.address.logic.commands.PlanCommand;
 import seedu.address.logic.commands.ShortcutCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.location.CombinedLocationPredicate;
-import seedu.address.model.location.Location;
+// import seedu.address.model.location.Location;
 import seedu.address.model.location.NameContainsKeywordsPredicate;
-import seedu.address.testutil.EditLocationDescriptorBuilder;
-import seedu.address.testutil.LocationBuilder;
-import seedu.address.testutil.LocationUtil;
+// import seedu.address.testutil.EditLocationDescriptorBuilder;
+// import seedu.address.testutil.LocationBuilder;
+// import seedu.address.testutil.LocationUtil;
 
 public class AddressBookParserTest {
 
@@ -98,13 +98,10 @@ public class AddressBookParserTest {
         assertTrue(parser.parseCommand(PlanCommand.COMMAND_WORD + " 2/3/12") instanceof PlanCommand);
     }
 
-    /*
     @Test
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
     }
-     */
 
     @Test
     public void parseCommand_helpOverview_success() throws Exception {
@@ -118,8 +115,9 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_helpMalformed_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE),
-                () -> parser.parseCommand("help add extra"));
+        assertThrows(ParseException.class,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
+                -> parser.parseCommand("help add extra"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HelpCommandParserTest.java
@@ -1,0 +1,38 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.HelpCommand;
+
+public class HelpCommandParserTest {
+
+    private final HelpCommandParser parser = new HelpCommandParser();
+
+    @Test
+    public void parse_noArguments_returnsOverviewHelpCommand() {
+        assertParseSuccess(parser, "", new HelpCommand());
+        assertParseSuccess(parser, "   ", new HelpCommand());
+    }
+
+    @Test
+    public void parse_validCommandWord_returnsContextualHelpCommand() {
+        assertParseSuccess(parser, "add", new HelpCommand(AddCommand.COMMAND_WORD));
+        assertParseSuccess(parser, "ADD", new HelpCommand(AddCommand.COMMAND_WORD));
+    }
+
+    @Test
+    public void parse_unknownCommandWord_throwsParseException() {
+        assertParseFailure(parser, "unknown", String.format(HelpCommand.MESSAGE_UNKNOWN_HELP_TOPIC, "unknown"));
+    }
+
+    @Test
+    public void parse_multipleArguments_throwsParseException() {
+        assertParseFailure(parser, "add extra",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HelpCommandParserTest.java
@@ -26,6 +26,11 @@ public class HelpCommandParserTest {
     }
 
     @Test
+    public void parse_linkFlag_returnsLinkHelpCommand() {
+        assertParseSuccess(parser, HelpCommand.LINK_FLAG, new HelpCommand(true));
+    }
+
+    @Test
     public void parse_unknownCommandWord_throwsParseException() {
         assertParseFailure(parser, "unknown", String.format(HelpCommand.MESSAGE_UNKNOWN_HELP_TOPIC, "unknown"));
     }

--- a/src/test/java/seedu/address/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HelpCommandParserTest.java
@@ -31,8 +31,8 @@ public class HelpCommandParserTest {
     }
 
     @Test
-    public void parse_unknownCommandWord_throwsParseException() {
-        assertParseFailure(parser, "unknown", String.format(HelpCommand.MESSAGE_UNKNOWN_HELP_TOPIC, "unknown"));
+    public void parse_unknownCommandWord_returnsContextualHelpCommand() {
+        assertParseSuccess(parser, "unknown", new HelpCommand("unknown"));
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR improves the `help` command by introducing offline CLI help, contextual command help, and explicit online help access for the project’s own User Guide.

**Key Features:**
- **Project User Guide Redirect**: Updated the help window link to open AddressMe’s deployed User Guide instead of the default AB3 guide.
- **Offline Help Overview**: `help` now shows a local summary of all supported commands directly in the CLI.
- **Contextual Help**: `help COMMAND_WORD` now shows command-specific guidance locally using each command’s existing usage definition.
- **Explicit Online Help Access**: Only `help -ug` opens the help window now, instead of opening it on every `help`.
- **Centralized Help Metadata**: Help summaries and detailed usage are sourced through `CommandDatabase` to reduce duplication and keep help output synchronized with command definitions.
- **Improved Parsing**: Added dedicated parsing support to distinguish between `help`, `help COMMAND_WORD`, and `help -ug`, with proper handling of invalid input.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Test Coverage
- [x] **Unit Tests**: Updated `HelpCommandTest` and `CommandDatabaseTest` to verify overview help, contextual help, link mode, and help content generation.
- [x] **Parser Tests**: Added/updated `HelpCommandParserTest` and `AddressBookParserTest` to verify parsing for `help`, `help COMMAND_WORD`, `help -ug`, invalid commands, and malformed input.
- [x] **Verification**: All existing and new tests pass successfully.

## Manual Testing Verification
- `help` → Displays a local overview of available commands in the CLI only.
- `help add` → Displays detailed local help for the `add` command.
- `help delete` → Displays detailed local help for the `delete` command.
- `help invalidcommand` → Shows an appropriate invalid help topic error.
- `help -ug` → Opens the help window with the project User Guide link.
- Pressing `F1` or using the help menu → Opens the project User Guide link in the help window.

## Related Issues
Closes #79

## Checklist for Reviewers
- [x] Code follows the project's coding style
- [x] Comments and documentation are clear and accurate
- [x] All tests pass locally
- [x] New tests added for new functionality
- [x] No breaking changes introduced
- [x] Edge cases handled (`help INVALID_COMMAND_WORD`, malformed help input, explicit link mode)
- [x] Help output stays synchronized with command usage strings
- [x] Online help now points to the correct project User Guide link

## Future Enhancements
Possible improvements for future iterations:
- Add richer formatting for CLI help output.
- Add shortcut-aware help resolution so aliases are supported. For example, if the shortcut `a -> add` exists, `help a` should behave the same as `help add`.