### PR TITLE
Fix locale-dependent date formatting

### DIFF
--- a/src/main/java/seedu/address/logic/parser/DateParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateParser.java
@@ -30,21 +30,21 @@ public class DateParser {
             + "\n The case does not matter.";
 
     private static final DateTimeFormatter DATE_FORMATTERS = new DateTimeFormatterBuilder()
-            .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
-            .appendOptional(DateTimeFormatter.ofPattern("yyyy/MM/dd"))
-            .appendOptional(DateTimeFormatter.ofPattern("yyyy-M-d"))
-            .appendOptional(DateTimeFormatter.ofPattern("d-M-yyyy"))
-            .appendOptional(DateTimeFormatter.ofPattern("yyyy/M/d"))
-            .appendOptional(DateTimeFormatter.ofPattern("d/M/yyyy"))
-            .appendOptional(DateTimeFormatter.ofPattern("d/M/yy"))
-            .appendOptional(DateTimeFormatter.ofPattern("d-M-yy"))
+            .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ENGLISH))
+            .appendOptional(DateTimeFormatter.ofPattern("yyyy/MM/dd", Locale.ENGLISH))
+            .appendOptional(DateTimeFormatter.ofPattern("yyyy-M-d", Locale.ENGLISH))
+            .appendOptional(DateTimeFormatter.ofPattern("d-M-yyyy", Locale.ENGLISH))
+            .appendOptional(DateTimeFormatter.ofPattern("yyyy/M/d", Locale.ENGLISH))
+            .appendOptional(DateTimeFormatter.ofPattern("d/M/yyyy", Locale.ENGLISH))
+            .appendOptional(DateTimeFormatter.ofPattern("d/M/yy", Locale.ENGLISH))
+            .appendOptional(DateTimeFormatter.ofPattern("d-M-yy", Locale.ENGLISH))
             .toFormatter();
 
     private static final DateTimeFormatter MONTH_DAY_FORMATTERS = new DateTimeFormatterBuilder()
-            .appendOptional(DateTimeFormatter.ofPattern("dd-MM"))
-            .appendOptional(DateTimeFormatter.ofPattern("dd/MM"))
-            .appendOptional(DateTimeFormatter.ofPattern("d/M"))
-            .appendOptional(DateTimeFormatter.ofPattern("d-M"))
+            .appendOptional(DateTimeFormatter.ofPattern("dd-MM", Locale.ENGLISH))
+            .appendOptional(DateTimeFormatter.ofPattern("dd/MM", Locale.ENGLISH))
+            .appendOptional(DateTimeFormatter.ofPattern("d/M", Locale.ENGLISH))
+            .appendOptional(DateTimeFormatter.ofPattern("d-M", Locale.ENGLISH))
             .toFormatter();
 
     private static final List<DateTimeFormatter> DAY_OF_WEEK_FORMATTER = List.of(

--- a/src/main/java/seedu/address/model/location/dates/OneTimeDate.java
+++ b/src/main/java/seedu/address/model/location/dates/OneTimeDate.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 import seedu.address.logic.parser.DateParser;
 
@@ -39,7 +40,7 @@ public class OneTimeDate extends VisitDate {
 
     @Override
     public String toString() {
-        return date.format(DateTimeFormatter.ofPattern("d MMM yy"));
+        return date.format(DateTimeFormatter.ofPattern("d MMM yy", Locale.ENGLISH));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/location/dates/YearlyRecurringDate.java
+++ b/src/main/java/seedu/address/model/location/dates/YearlyRecurringDate.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.time.LocalDate;
 import java.time.MonthDay;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 import seedu.address.logic.parser.DateParser;
 
@@ -14,8 +15,8 @@ import seedu.address.logic.parser.DateParser;
 public class YearlyRecurringDate extends VisitDate {
     public static final String MESSAGE_CONSTRAINTS = DateParser.MESSAGE_WRONG_DATE_FORMAT;
 
-    private static final DateTimeFormatter PRETTY_FORMAT = DateTimeFormatter.ofPattern("dd MMM");
-    private static final DateTimeFormatter DATA_FORMAT = DateTimeFormatter.ofPattern("dd/MM");
+    private static final DateTimeFormatter PRETTY_FORMAT = DateTimeFormatter.ofPattern("dd MMM", Locale.ENGLISH);
+    private static final DateTimeFormatter DATA_FORMAT = DateTimeFormatter.ofPattern("dd/MM", Locale.ENGLISH);
     private final MonthDay date;
 
     /**


### PR DESCRIPTION
## Summary
Fix date formatting so output is consistent across different system locales.

## Problem
Some tests failed on systems using a non-English locale because month names were formatted using the system default locale.

Example:
- Expected: `24 Mar 26`
- Actual on Chinese system: `24 3月 26`

This caused locale-dependent test failures and inconsistent user-facing date output.

## Changes made
- Set date formatters to use `Locale.ENGLISH`
- Standardized date output formatting across environments
- Ensured tests no longer depend on the machine's default locale

## Why this fix is needed
Without this fix, teammates using different system languages may see different date strings and get failing tests even when the logic is correct.

## Testing
- Ran `./gradlew test`
- Verified date-related outputs are shown in English format consistently

## Evidence
Example failing output before fix:
- `24 3月 26` instead of `24 Mar 26`
- `26 7月 00` instead of `26 Jul 00`

## Related issue
Closes #130 

This was reproduced on a laptop using a Chinese system locale.