### PR TITLE
Fix find command not rejecting unsupported prefixes (e.g. o/)

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -13,6 +13,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.FindCommand;
@@ -37,6 +39,11 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
+
+        if (containsUnsupportedPrefix(args)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_ADDRESS, PREFIX_TAG, PREFIX_DATE);
@@ -104,6 +111,34 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         return new FindCommand(new CombinedLocationPredicate(predicates));
+    }
+
+    /**
+     * Returns true if the input contains a prefix not supported by find.
+     */
+    private boolean containsUnsupportedPrefix(String args) {
+        Pattern pattern = Pattern.compile("(^|\\s)([a-zA-Z]+/)");
+        Matcher matcher = pattern.matcher(args);
+
+        while (matcher.find()) {
+            String prefix = matcher.group(2);
+            if (!isSupportedPrefix(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the prefix is supported by find.
+     */
+    private boolean isSupportedPrefix(String prefix) {
+        return prefix.equals(PREFIX_NAME.getPrefix())
+                || prefix.equals(PREFIX_PHONE.getPrefix())
+                || prefix.equals(PREFIX_EMAIL.getPrefix())
+                || prefix.equals(PREFIX_ADDRESS.getPrefix())
+                || prefix.equals(PREFIX_TAG.getPrefix())
+                || prefix.equals(PREFIX_DATE.getPrefix());
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -160,4 +160,16 @@ public class FindCommandParserTest {
                 new NameContainsKeywordsPredicate(Arrays.asList("aLi")))));
         assertParseSuccess(parser, "aLi", expectedFindCommand);
     }
+
+    @Test
+    void parse_unsupportedPrefix_throwsParseException() {
+        assertParseFailure(parser, " o/123",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    void parse_supportedAndUnsupportedPrefix_throwsParseException() {
+        assertParseFailure(parser, " n/John o/123",
+                           String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
 }


### PR DESCRIPTION
## Summary
Fixes an issue where the `find` command accepts unsupported prefixes (e.g. `o/123`) without error and returns a misleading result ("0 locations listed") instead of rejecting the input.  close #126 

## Problem
Currently, the `find` command ignores unsupported prefixes. For example:

find o/123

The command executes and returns "0 locations listed", which is misleading because the input itself is invalid.

This can confuse users into thinking no matching results exist, rather than recognizing that the command format is incorrect.

## Solution
Added validation in `FindCommandParser` to detect unsupported prefixes before parsing.

If an unsupported prefix is found, the parser now throws a `ParseException` and shows the correct usage message.

## Before
- Invalid prefix accepted silently
- Returns "0 locations listed"
- Misleading behavior

## After
- Invalid prefix is rejected
- Proper error message shown
- Consistent with command format validation

## Tests
Added tests to ensure:
- Unsupported prefix (e.g. `o/123`) throws `ParseException`
- Mixed valid + invalid prefixes are rejected

## Notes
This improves user experience by preventing silent failures and ensuring clearer feedback for incorrect inputs.