### PR TITLE
Introduce dirty tracking to prevent unnecessary save after every command

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -190,6 +190,11 @@ The relevant model operations are:
 
 `add`, `edit`, `delete`, `clear`, `shortcut set` and `shortcut remove` return `true` for `isStateMutating()`. Non-mutating commands such as `list`, `find` and `plan` do not change undo/redo history. `note` is excluded because it does not persist any model state yet. `undo` and `redo` themselves also do not create new history entries.
 
+Persistence is tracked separately from undo/redo history. `ModelManager` maintains dirty flags for the address book,
+shortcut map, and user preferences, and `LogicManager` only saves the storage slices that have unsaved changes after a
+successful command. As a result, read-only commands such as `list`, `find`, and `plan` do not trigger unnecessary disk
+writes, while commands such as `theme`, `undo`, and `redo` still persist the correct data.
+
 #### Behavior
 
 The implementation is intentionally limited to one level:
@@ -538,9 +543,8 @@ Use case ends.
 
 **MSS**
 
-1. User enters the save/exit command.
-2. System saves the data.
-3. System closes the application.
+1. User enters the exit command.
+2. System closes the application.
 Use case ends.
 
 **Extensions**

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -421,7 +421,7 @@ Format: `clear`
 
 ### `exit` - Exiting the program
 
-Closes AddressMe. Data that was changed by previous commands is already saved automatically; no manual save command is required.
+Closes AddressMe. Your data is saved after relevant commands; no need to manually save.
 
 Format: `exit`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -421,7 +421,7 @@ Format: `clear`
 
 ### `exit` - Exiting the program
 
-Closes AddressMe. Your data and shortcuts are saved automatically.
+Closes AddressMe. Data that was changed by previous commands is already saved automatically; no manual save command is required.
 
 Format: `exit`
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -67,11 +67,7 @@ public class LogicManager implements Logic {
             throw e;
         }
 
-        saveAddressBook();
-        saveShortcuts();
-        // Save user preferences as a best-effort operation. Failures here should not cause the entire
-        // command to be reported as failed when the address book has already been successfully persisted.
-        savePreferences();
+        saveDirtyPersistentState();
 
         return commandResult;
     }
@@ -98,9 +94,24 @@ public class LogicManager implements Logic {
         return commandResult;
     }
 
+    private void saveDirtyPersistentState() throws CommandException {
+        if (model.hasUnsavedAddressBookChanges()) {
+            saveAddressBook();
+        }
+
+        if (model.hasUnsavedShortcutMapChanges()) {
+            saveShortcuts();
+        }
+
+        if (model.hasUnsavedUserPrefsChanges()) {
+            savePreferences();
+        }
+    }
+
     private void saveAddressBook() throws CommandException {
         try {
             storage.saveAddressBook(model.getAddressBook());
+            model.markAddressBookSaved();
         } catch (AccessDeniedException e) {
             throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
         } catch (IOException ioe) {
@@ -111,6 +122,7 @@ public class LogicManager implements Logic {
     private void saveShortcuts() {
         try {
             storage.saveShortcutMap(model.getShortcutMap());
+            model.markShortcutMapSaved();
         } catch (AccessDeniedException e) {
             logger.warning(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()));
         } catch (IOException ioe) {
@@ -121,6 +133,7 @@ public class LogicManager implements Logic {
     private void savePreferences() {
         try {
             storage.saveUserPrefs(model.getUserPrefs());
+            model.markUserPrefsSaved();
         } catch (AccessDeniedException e) {
             logger.warning(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()));
         } catch (IOException ioe) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -127,6 +127,42 @@ public interface Model {
      */
     default void redoState() {}
 
+    /**
+     * Returns true if the persisted address book differs from the last successful save.
+     */
+    default boolean hasUnsavedAddressBookChanges() {
+        return false;
+    }
+
+    /**
+     * Returns true if the persisted shortcut map differs from the last successful save.
+     */
+    default boolean hasUnsavedShortcutMapChanges() {
+        return false;
+    }
+
+    /**
+     * Returns true if the persisted user preferences differ from the last successful save.
+     */
+    default boolean hasUnsavedUserPrefsChanges() {
+        return false;
+    }
+
+    /**
+     * Marks the address book as saved after a successful persistence operation.
+     */
+    default void markAddressBookSaved() {}
+
+    /**
+     * Marks the shortcut map as saved after a successful persistence operation.
+     */
+    default void markShortcutMapSaved() {}
+
+    /**
+     * Marks the user preferences as saved after a successful persistence operation.
+     */
+    default void markUserPrefsSaved() {}
+
     /** Returns the AddressBook */
     ReadOnlyAddressBook getAddressBook();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -36,6 +36,9 @@ public class ModelManager implements Model {
     private AppState undoState;
     private AppState redoState;
     private AppState pendingState;
+    private boolean hasUnsavedAddressBookChanges;
+    private boolean hasUnsavedShortcutMapChanges;
+    private boolean hasUnsavedUserPrefsChanges;
 
     private final ObjectProperty<NoteContent> plannerNote;
     private LocalDate currentPlannedDate;
@@ -69,6 +72,7 @@ public class ModelManager implements Model {
     public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
         requireNonNull(userPrefs);
         this.userPrefs.resetData(userPrefs);
+        hasUnsavedUserPrefsChanges = true;
     }
 
     @Override
@@ -90,12 +94,14 @@ public class ModelManager implements Model {
     public void setGuiSettings(GuiSettings guiSettings) {
         requireNonNull(guiSettings);
         userPrefs.setGuiSettings(guiSettings);
+        hasUnsavedUserPrefsChanges = true;
     }
 
     @Override
     public void setTheme(Theme theme) {
         requireNonNull(theme);
         userPrefs.setTheme(theme);
+        hasUnsavedUserPrefsChanges = true;
     }
 
     @Override
@@ -107,6 +113,7 @@ public class ModelManager implements Model {
     public void setAddressBookFilePath(Path addressBookFilePath) {
         requireNonNull(addressBookFilePath);
         userPrefs.setAddressBookFilePath(addressBookFilePath);
+        hasUnsavedUserPrefsChanges = true;
     }
 
     //=========== ShortcutMap ================================================================================
@@ -126,12 +133,14 @@ public class ModelManager implements Model {
     public void setShortcut(String alias, String commandWord) {
         requireAllNonNull(alias, commandWord);
         shortcutMap.setShortcut(alias, commandWord);
+        hasUnsavedShortcutMapChanges = true;
     }
 
     @Override
     public void removeShortcut(String alias) {
         requireNonNull(alias);
         shortcutMap.removeShortcut(alias);
+        hasUnsavedShortcutMapChanges = true;
     }
 
     //=========== AddressBook ================================================================================
@@ -139,6 +148,7 @@ public class ModelManager implements Model {
     @Override
     public void setAddressBook(ReadOnlyAddressBook addressBook) {
         this.addressBook.resetData(addressBook);
+        hasUnsavedAddressBookChanges = true;
         updatePlannerNote();
     }
 
@@ -192,6 +202,36 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasUnsavedAddressBookChanges() {
+        return hasUnsavedAddressBookChanges;
+    }
+
+    @Override
+    public boolean hasUnsavedShortcutMapChanges() {
+        return hasUnsavedShortcutMapChanges;
+    }
+
+    @Override
+    public boolean hasUnsavedUserPrefsChanges() {
+        return hasUnsavedUserPrefsChanges;
+    }
+
+    @Override
+    public void markAddressBookSaved() {
+        hasUnsavedAddressBookChanges = false;
+    }
+
+    @Override
+    public void markShortcutMapSaved() {
+        hasUnsavedShortcutMapChanges = false;
+    }
+
+    @Override
+    public void markUserPrefsSaved() {
+        hasUnsavedUserPrefsChanges = false;
+    }
+
+    @Override
     public ReadOnlyAddressBook getAddressBook() {
         return addressBook;
     }
@@ -205,11 +245,13 @@ public class ModelManager implements Model {
     @Override
     public void deleteLocation(Location target) {
         addressBook.removeLocation(target);
+        hasUnsavedAddressBookChanges = true;
     }
 
     @Override
     public void addLocation(Location location) {
         addressBook.addLocation(location);
+        hasUnsavedAddressBookChanges = true;
         updateFilteredLocationList(PREDICATE_SHOW_ALL_LOCATIONS);
     }
 
@@ -218,6 +260,7 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedLocation);
 
         addressBook.setLocation(target, editedLocation);
+        hasUnsavedAddressBookChanges = true;
     }
 
     //=========== Filtered Location List Accessors =============================================================
@@ -285,6 +328,7 @@ public class ModelManager implements Model {
     public void setNote(VisitDate date, NoteContent note) {
         requireAllNonNull(date, note);
         addressBook.setNote(date, note);
+        hasUnsavedAddressBookChanges = true;
         if (currentPlannedDate != null && date.isOn(currentPlannedDate)) {
             updatePlannerNote();
         }
@@ -316,8 +360,16 @@ public class ModelManager implements Model {
     }
 
     private void restoreState(AppState state) {
-        setAddressBook(state.addressBook());
-        shortcutMap.resetData(state.shortcutMap());
+        if (!addressBook.equals(state.addressBook())) {
+            addressBook.resetData(state.addressBook());
+            hasUnsavedAddressBookChanges = true;
+            updatePlannerNote();
+        }
+
+        if (!shortcutMap.equals(state.shortcutMap())) {
+            shortcutMap.resetData(state.shortcutMap());
+            hasUnsavedShortcutMapChanges = true;
+        }
     }
 
     private record AppState(AddressBook addressBook, ShortcutMap shortcutMap) {

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -253,6 +253,7 @@ public class LogicManagerTest {
         assertThrows(UnsupportedOperationException.class, () -> logic.getPlannerLocationList().remove(0));
     }
 
+    //@@author Zhenghao229
     @Test
     public void execute_addNote_success() throws Exception {
         String inputCommand = "note n/Test Note d/2026-03-24";
@@ -284,6 +285,7 @@ public class LogicManagerTest {
 
         assertCommandException(inputCommand, DeleteNoteCommand.MESSAGE_NO_NOTES_FOUND);
     }
+    //@@author
 
     /**
      * Executes the command and confirms that

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.POSTAL_CODE_DESC_AMY;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalLocations.AMY;
+import static seedu.address.testutil.TypicalLocations.getTypicalAddressBook;
 
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
@@ -25,6 +26,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.ShortcutCommand;
+import seedu.address.logic.commands.ThemeCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -32,12 +34,17 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyShortcutMap;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.ShortcutMap;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.location.Location;
+import seedu.address.storage.AddressBookStorage;
 import seedu.address.storage.JsonAddressBookStorage;
 import seedu.address.storage.JsonShortcutStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
+import seedu.address.storage.ShortcutStorage;
 import seedu.address.storage.StorageManager;
+import seedu.address.storage.UserPrefsStorage;
 import seedu.address.testutil.LocationBuilder;
 
 public class LogicManagerTest {
@@ -177,6 +184,51 @@ public class LogicManagerTest {
     @Test
     public void execute_shortcutStorageThrowsAdException_commandSucceeds() throws Exception {
         assertCommandSuccessForExceptionFromShortcutStorage(DUMMY_AD_EXCEPTION);
+    }
+
+    @Test
+    public void execute_nonPersistentCommand_doesNotTriggerStorageWrites() throws Exception {
+        CountingStorageManager storage = createCountingStorage();
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ShortcutMap());
+        logic = new LogicManager(model, storage);
+
+        CommandResult result = logic.execute("find Meier");
+
+        assertEquals(String.format(Messages.MESSAGE_LOCATIONS_LISTED_OVERVIEW, 2), result.getFeedbackToUser());
+        assertEquals(0, storage.addressBookSaveCount);
+        assertEquals(0, storage.shortcutSaveCount);
+        assertEquals(0, storage.userPrefsSaveCount);
+    }
+
+    @Test
+    public void execute_themeCommand_savesOnlyUserPrefs() throws Exception {
+        CountingStorageManager storage = createCountingStorage();
+        logic = new LogicManager(model, storage);
+
+        assertCommandSuccess(ThemeCommand.COMMAND_WORD + " dark",
+                String.format(ThemeCommand.MESSAGE_SUCCESS, "dark"), createModelWithTheme(Theme.DARK));
+
+        assertEquals(0, storage.addressBookSaveCount);
+        assertEquals(0, storage.shortcutSaveCount);
+        assertEquals(1, storage.userPrefsSaveCount);
+    }
+
+    @Test
+    public void execute_undoCommand_savesOnlyChangedPersistentState() throws Exception {
+        CountingStorageManager storage = createCountingStorage();
+        logic = new LogicManager(model, storage);
+
+        String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
+                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + POSTAL_CODE_DESC_AMY + DATE_DESC_AMY;
+
+        logic.execute(addCommand);
+        storage.resetCounts();
+
+        assertCommandSuccess(UndoCommand.COMMAND_WORD, UndoCommand.MESSAGE_SUCCESS, new ModelManager());
+
+        assertEquals(1, storage.addressBookSaveCount);
+        assertEquals(0, storage.shortcutSaveCount);
+        assertEquals(0, storage.userPrefsSaveCount);
     }
 
     @Test
@@ -336,6 +388,51 @@ public class LogicManagerTest {
         ModelManager expectedModel = new ModelManager();
         expectedModel.setShortcut(alias, commandWord);
         return expectedModel;
+    }
+
+    private CountingStorageManager createCountingStorage() {
+        JsonAddressBookStorage addressBookStorage =
+                new JsonAddressBookStorage(temporaryFolder.resolve("CountingAddressBook.json"));
+        JsonUserPrefsStorage userPrefsStorage =
+                new JsonUserPrefsStorage(temporaryFolder.resolve("CountingUserPrefs.json"));
+        JsonShortcutStorage shortcutStorage =
+                new JsonShortcutStorage(temporaryFolder.resolve("CountingShortcut.json"));
+        return new CountingStorageManager(addressBookStorage, userPrefsStorage, shortcutStorage);
+    }
+
+    private static class CountingStorageManager extends StorageManager {
+        private int addressBookSaveCount;
+        private int shortcutSaveCount;
+        private int userPrefsSaveCount;
+
+        private CountingStorageManager(AddressBookStorage addressBookStorage, UserPrefsStorage userPrefsStorage,
+                                       ShortcutStorage shortcutStorage) {
+            super(addressBookStorage, userPrefsStorage, shortcutStorage);
+        }
+
+        @Override
+        public void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException {
+            addressBookSaveCount++;
+            super.saveAddressBook(addressBook);
+        }
+
+        @Override
+        public void saveShortcutMap(ReadOnlyShortcutMap shortcutMap) throws IOException {
+            shortcutSaveCount++;
+            super.saveShortcutMap(shortcutMap);
+        }
+
+        @Override
+        public void saveUserPrefs(ReadOnlyUserPrefs userPrefs) throws IOException {
+            userPrefsSaveCount++;
+            super.saveUserPrefs(userPrefs);
+        }
+
+        private void resetCounts() {
+            addressBookSaveCount = 0;
+            shortcutSaveCount = 0;
+            userPrefsSaveCount = 0;
+        }
     }
 }
 


### PR DESCRIPTION
## Description
This PR reduces unnecessary persistence work in `LogicManager` by saving only the parts of the model that actually changed after a command executes. Previously, every successful command triggered three disk write attempts for the address book, shortcut map, and user preferences, even for read-only commands such as `list`, `find`, `help`, or `plan`.

The refactor introduces model-level dirty tracking so persistence decisions are based on actual persisted state changes instead of command type alone.

**Key Features:**
- **Selective Persistence**: `LogicManager` now saves only dirty persistent state instead of always writing all three stores after every command.
- **Model-Level Dirty Tracking**: `ModelManager` tracks unsaved changes separately for the address book, shortcut map, and user preferences.
- **Accurate Save Semantics**: Commands that modify persisted state indirectly, such as `undo`, `redo`, and `theme`, still trigger the correct saves.
- **Read-Only Command Optimization**: Commands like `list`, `find`, `help`, and `plan` no longer cause unnecessary disk I/O.
- **Save Retry Safety**: Dirty flags are cleared only after a successful save, so failed persistence attempts are retried on later commands.
- **State-Aware Restore Logic**: Undo/redo restore paths only mark the storage slices that actually changed.

## Type of Change
- [ ] New feature (non-breaking change that adds functionality)
- [x] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Test Coverage
- [x] **Unit Tests**: Added and updated tests for selective save behavior in `LogicManager`.
- [x] **Integration Tests**: Verified command execution still behaves correctly for normal, undo/redo, and preference-changing commands.
- [x] **Regression Coverage**: Added checks that read-only commands do not trigger storage writes, while `theme` and `undo` still persist correctly.
- [x] **Verification**: Full test suite was executed successfully with `.\gradlew.bat test`.

## Manual Testing Verification
- Run `list` repeatedly -> No unnecessary address book / shortcut / prefs writes are triggered
- Run `find Meier` repeatedly -> Search works normally without repeated persistence
- Run `plan 2026-03-16` -> Planner updates without triggering storage writes
- Run `theme dark` -> Theme changes and user preferences are persisted
- Run `shortcut set a add` -> Shortcut is persisted as expected
- Run `add ...` -> Address book changes are persisted as expected
- Run `undo` after `add` -> Reverted address book state is persisted correctly
- Run `redo` after `undo` -> Restored state is persisted correctly
- Simulate a shortcut or prefs save failure -> Unsaved changes remain pending for retry on a later command

## Related Issues
Closes #148 

## Checklist for Reviewers
- [x] Code follows the project's coding style
- [x] Comments and documentation are clear and accurate
- [x] All tests pass locally
- [x] New tests added for changed behavior
- [x] No breaking changes introduced
- [x] Read-only commands no longer trigger unnecessary persistence
- [x] `undo`, `redo`, and `theme` still persist the correct state
- [x] Dirty flags are cleared only after successful saves
- [x] Persistence responsibilities remain centralized in logic/model flow