### PR TITLE
Make DeleteNote unodable and update UG/DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -188,7 +188,7 @@ The relevant model operations are:
 4. If execution succeeds, call `Model#commitState()`.
 5. If execution fails, call `Model#discardState()` so failed commands do not affect undo history.
 
-`add`, `edit`, `delete`, `clear`, `shortcut set` and `shortcut remove` return `true` for `isStateMutating()`. Non-mutating commands such as `list`, `find` and `plan` do not change undo/redo history. `note` is excluded because it does not persist any model state yet. `undo` and `redo` themselves also do not create new history entries.
+`add`, `edit`, `delete`, `clear`, `note`, `shortcut set` and `shortcut remove` return `true` for `isStateMutating()`. Non-mutating commands such as `list`, `find` and `plan` do not change undo/redo history. `undo` and `redo` themselves also do not create new history entries.
 
 Persistence is tracked separately from undo/redo history. `ModelManager` maintains dirty flags for the address book,
 shortcut map, and user preferences, and `LogicManager` only saves the storage slices that have unsaved changes after a

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -355,13 +355,13 @@ Reverts the most recent successful undoable change.
 Format: `undo`
 
 * `undo` currently supports only one level of history.
-* Successful `add`, `edit`, `delete`, `clear`, `shortcut set` and `shortcut remove` commands are undoable.
+* Successful `add`, `edit`, `delete`, `clear`, `note`, `shortcut set` and `shortcut remove` commands are undoable.
 * Commands that do not change undoable state, such as `list`, `find` and `plan`, do not affect undo history.
-* `note` is not undoable yet because it currently validates input and shows a confirmation message without persisting data.
 * If there is nothing to undo, AddressMe shows an error message.
 
 Examples:
 * `delete 3` followed by `undo` restores the deleted location.
+* `note n/Involves lots of walking. Bring extra water bottles. d/2026-03-24` followed by `undo` removes the note again.
 * `shortcut set a add` followed by `undo` removes the shortcut again.
 
 ### `redo` - Redoing the last undo

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -50,6 +50,11 @@ public class DeleteNoteCommand extends Command {
     }
 
     @Override
+    public boolean isStateMutating() {
+        return true;
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -287,6 +287,18 @@ public class LogicManagerTest {
     }
     //@@author
 
+    @Test
+    public void execute_undoRedoNoteChange_success() throws Exception {
+        String noteCommand = "note n/Test Note d/2026-03-24";
+
+        logic.execute(noteCommand);
+        assertCommandSuccess(UndoCommand.COMMAND_WORD, UndoCommand.MESSAGE_SUCCESS, new ModelManager());
+
+        ModelManager expectedModel = new ModelManager();
+        expectedModel.setNote(VisitDate.of("2026-03-24"), new NoteContent("Test Note"));
+        assertCommandSuccess(RedoCommand.COMMAND_WORD, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
     /**
      * Executes the command and confirms that
      * - no exceptions are thrown

--- a/src/test/java/seedu/address/logic/commands/DeleteNoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteNoteCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 
@@ -59,6 +60,12 @@ public class DeleteNoteCommandTest {
         DeleteNoteCommand command = new DeleteNoteCommand(date);
 
         assertEquals(date, command.getDate());
+    }
+
+    @Test
+    public void isStateMutating() throws IllegalValueException {
+        DeleteNoteCommand command = new DeleteNoteCommand(VisitDate.of("2026-03-24"));
+        assertTrue(command.isStateMutating());
     }
 
     @Test


### PR DESCRIPTION
As per title. Add Note was already marked state-mutating and thus undo/redoable.

Updated UG and DG to reflect changes.

Fixes #155 