### PR TITLE
Check for duplicate location via Address + Postal Code first AND Dark Theme adjustment

### DIFF
--- a/src/main/java/seedu/address/model/location/Location.java
+++ b/src/main/java/seedu/address/model/location/Location.java
@@ -134,16 +134,39 @@ public class Location {
     }
 
     /**
-     * Returns true if both locations have the same name.
-     * This defines a weaker notion of equality between two locations.
+     * Returns true if both locations have the same identity.
+     * Identity is compared using postal code and address when both are present,
+     * otherwise address alone, and finally name as the last fallback.
      */
     public boolean isSameLocation(Location otherLocation) {
         if (otherLocation == this) {
             return true;
         }
 
-        return otherLocation != null
-                && otherLocation.getName().isSameNameIgnoreCase(getName());
+        if (otherLocation == null) {
+            return false;
+        }
+
+        boolean hasPostalAndAddress = postalCode.isPresent() && otherLocation.postalCode.isPresent()
+                && address.isPresent() && otherLocation.address.isPresent();
+        if (hasPostalAndAddress) {
+            return postalCode.equals(otherLocation.postalCode)
+                    && hasSameAddressIgnoreCase(otherLocation);
+        }
+
+        if (address.isPresent() && otherLocation.address.isPresent()) {
+            return hasSameAddressIgnoreCase(otherLocation);
+        }
+
+        return otherLocation.getName().isSameNameIgnoreCase(getName());
+    }
+
+    private boolean hasSameAddressIgnoreCase(Location otherLocation) {
+        if (address.isEmpty() || otherLocation.address.isEmpty()) {
+            return false;
+        }
+
+        return address.get().toString().equalsIgnoreCase(otherLocation.address.get().toString());
     }
 
     /**

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -173,7 +173,7 @@
 }
 
 .note-area {
-    -fx-background-color: #0f4c81;
+    -fx-background-color: #0b3353;
     -fx-padding: 3 0 0 8;
 
     -fx-border-color: #e0e0e0;
@@ -184,7 +184,7 @@
     /* red margin line */
     -fx-border-insets: 0 0 0 0;
     -fx-border-width: 0 0 0 2;
-    -fx-border-color: transparent transparent transparent #ff6b6b;
+    -fx-border-color: transparent transparent transparent #93013c;
 }
 
 .note-label {

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateLocationAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateLocationAddressBook.json
@@ -1,16 +1,18 @@
 {
   "locations": [ {
-    "name": "Alice Pauline",
+    "name": "Sample Place One",
     "phone": "94351253",
-    "email": "alice@example.com",
+    "email": "sample1@example.com",
     "address": "123, Jurong West Ave 6, #08-111",
+    "postalCode": "640123",
     "visitDates": ["2026-01-01"],
     "tags": [ "friends" ]
   }, {
-    "name": "Alice Pauline",
+    "name": "Allegedly Different Place",
     "phone": "94351253",
-    "email": "pauline@example.com",
-    "visitDates": ["2026-02-01"],
-    "address": "4th street"
+    "email": "sample2@example.com",
+    "address": "123, Jurong West Ave 6, #08-111",
+    "postalCode": "640123",
+    "visitDates": ["2026-02-01"]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -29,7 +29,11 @@ public class AddCommandIntegrationTest {
 
     @Test
     public void execute_newLocation_success() {
-        Location validLocation = new LocationBuilder().build();
+        Location validLocation = new LocationBuilder()
+                .withName("New Place")
+                .withAddress("77 Sunset Way")
+                .withPostalCode("765432")
+                .build();
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new ShortcutMap());
         expectedModel.addLocation(validLocation);

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -3,10 +3,11 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalLocations.ALICE;
+import static seedu.address.testutil.TypicalLocations.ZERO;
 import static seedu.address.testutil.TypicalLocations.getTypicalAddressBook;
 
 import java.util.Arrays;
@@ -50,7 +51,7 @@ public class AddressBookTest {
     @Test
     public void resetData_withDuplicateLocations_throwsDuplicateLocationException() {
         // Two locations with the same identity fields
-        Location editedAlice = new LocationBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Location editedAlice = new LocationBuilder(ALICE).withName(VALID_NAME_BOB).withTags(VALID_TAG_HUSBAND)
                 .build();
         List<Location> newLocations = Arrays.asList(ALICE, editedAlice);
         AddressBookStub newData = new AddressBookStub(newLocations);
@@ -77,9 +78,28 @@ public class AddressBookTest {
     @Test
     public void hasLocation_locationWithSameIdentityFieldsInAddressBook_returnsTrue() {
         addressBook.addLocation(ALICE);
-        Location editedAlice = new LocationBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Location editedAlice = new LocationBuilder(ALICE).withName(VALID_NAME_BOB).withTags(VALID_TAG_HUSBAND)
                 .build();
         assertTrue(addressBook.hasLocation(editedAlice));
+    }
+
+    @Test
+    public void hasLocation_locationWithSameNameOnlyButDifferentAddress_returnsFalse() {
+        addressBook.addLocation(ALICE);
+        Location editedAlice = new LocationBuilder(ALICE)
+                .withAddress("77 Sunset Way")
+                .withPostalCode("765432")
+                .build();
+        assertFalse(addressBook.hasLocation(editedAlice));
+    }
+
+    @Test
+    public void hasLocation_locationWithoutAddressSameNameDifferentCase_returnsTrue() {
+        addressBook.addLocation(ZERO);
+        Location editedZero = new LocationBuilder(ZERO)
+                .withName(ZERO.getName().fullName.toLowerCase())
+                .build();
+        assertTrue(addressBook.hasLocation(editedZero));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/location/LocationTest.java
+++ b/src/test/java/seedu/address/model/location/LocationTest.java
@@ -47,18 +47,39 @@ public class LocationTest {
         assertFalse(ALICE.isSameLocation(null));
 
         Location editedAlice = new LocationBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
+                .withTags(VALID_TAG_HUSBAND).build();
         assertTrue(ALICE.isSameLocation(editedAlice));
 
-        editedAlice = new LocationBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        editedAlice = new LocationBuilder(ALICE).withPostalCode("999999").build();
         assertFalse(ALICE.isSameLocation(editedAlice));
 
-        Location editedBob = new LocationBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertTrue(BOB.isSameLocation(editedBob));
+        Location namelessAddressFallback = new LocationBuilder(ZERO)
+                .withName(ZERO.getName().fullName.toLowerCase())
+                .build();
+        assertTrue(ZERO.isSameLocation(namelessAddressFallback));
+
+        Location addressOnly = new LocationBuilder(ZERO)
+                .withAddress(VALID_ADDRESS_BOB)
+                .withPostalCode("999999")
+                .build();
+        Location addressFallbackMatch = new LocationBuilder(addressOnly)
+                .withName(VALID_NAME_BOB.toLowerCase())
+                .withAddress(VALID_ADDRESS_BOB.toLowerCase())
+                .withoutPostalCode()
+                .build();
+        assertTrue(addressOnly.isSameLocation(addressFallbackMatch));
+
+        Location postalAndAddressCaseInsensitive = new LocationBuilder(ALICE)
+                .withAddress(ALICE.getAddressString().toLowerCase())
+                .build();
+        assertTrue(ALICE.isSameLocation(postalAndAddressCaseInsensitive));
+
+        Location differentAddress = new LocationBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).build();
+        assertFalse(ALICE.isSameLocation(differentAddress));
 
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new LocationBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSameLocation(editedBob));
+        Location fallbackNameMismatch = new LocationBuilder(ZERO).withName(nameWithTrailingSpaces).build();
+        assertFalse(ZERO.isSameLocation(fallbackNameMismatch));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/location/UniqueLocationListTest.java
+++ b/src/test/java/seedu/address/model/location/UniqueLocationListTest.java
@@ -3,11 +3,12 @@ package seedu.address.model.location;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalLocations.ALICE;
 import static seedu.address.testutil.TypicalLocations.BOB;
+import static seedu.address.testutil.TypicalLocations.ZERO;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,7 +43,7 @@ public class UniqueLocationListTest {
     @Test
     public void contains_locationWithSameIdentityFieldsInList_returnsTrue() {
         uniqueLocationList.add(ALICE);
-        Location editedAlice = new LocationBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Location editedAlice = new LocationBuilder(ALICE).withName(VALID_NAME_BOB).withTags(VALID_TAG_HUSBAND)
                 .build();
         assertTrue(uniqueLocationList.contains(editedAlice));
     }
@@ -85,7 +86,7 @@ public class UniqueLocationListTest {
     @Test
     public void setLocation_editedLocationHasSameIdentity_success() {
         uniqueLocationList.add(ALICE);
-        Location editedAlice = new LocationBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Location editedAlice = new LocationBuilder(ALICE).withName(VALID_NAME_BOB).withTags(VALID_TAG_HUSBAND)
                 .build();
         uniqueLocationList.setLocation(ALICE, editedAlice);
         UniqueLocationList expectedUniqueLocationList = new UniqueLocationList();
@@ -175,13 +176,38 @@ public class UniqueLocationListTest {
     }
 
     @Test
-    public void contains_locationWithSameNameDifferentCase_returnsTrue() {
-        uniqueLocationList.add(ALICE);
+    public void contains_locationWithSameAddressDifferentName_returnsTrue() {
+        Location locationWithoutPostalCode = new LocationBuilder(ALICE)
+                .withoutPostalCode()
+                .build();
+        uniqueLocationList.add(locationWithoutPostalCode);
 
-        Location editedAlice = new LocationBuilder(ALICE)
-                .withName(ALICE.getName().fullName.toLowerCase()) // or "sunrise cafe"
+        Location editedAlice = new LocationBuilder(locationWithoutPostalCode)
+                .withName(ALICE.getName().fullName.toLowerCase())
                 .build();
 
         assertTrue(uniqueLocationList.contains(editedAlice));
+    }
+
+    @Test
+    public void contains_locationWithSameAddressDifferentPostalCode_returnsFalse() {
+        uniqueLocationList.add(ALICE);
+
+        Location editedAlice = new LocationBuilder(ALICE)
+                .withPostalCode("999999")
+                .build();
+
+        assertFalse(uniqueLocationList.contains(editedAlice));
+    }
+
+    @Test
+    public void contains_locationWithoutAddressSameNameDifferentCase_returnsTrue() {
+        uniqueLocationList.add(ZERO);
+
+        Location editedZero = new LocationBuilder(ZERO)
+                .withName(ZERO.getName().fullName.toLowerCase())
+                .build();
+
+        assertTrue(uniqueLocationList.contains(editedZero));
     }
 }


### PR DESCRIPTION
## Summary
Update location duplicate detection to use stronger physical-location identity instead of name-only matching. Locations are now considered the same by this priority:

1. `postalCode + address`
2. `address`
3. `name` as a last fallback when address is missing

**Thoughts on this order? Suggest alternatives if you want!**

Address matching in similarity checks is also now case-insensitive.

## Problem
Previously, `isSameLocation(...)` only matched by name, which allowed duplicate real-world locations to be added if their names differed slightly, such as `McDonald's` vs `McDonalds`, even when address and contact details referred to the same place.

## Changes
- Updated `Location.isSameLocation(...)` to compare identity using:
  - postal code and address when both are present
  - address when postal code is unavailable
  - case-insensitive name only when address is unavailable
- Made address comparison in similarity checks case-insensitive
- Kept strict object equality unchanged
- Updated unit, integration, and storage tests to reflect the new identity rule
- Updated duplicate JSON test data to represent duplicates under the new semantics

## Why
This better reflects how itinerary locations are identified in practice:
- physical address is a stronger signal than display name
- postal code strengthens address matching when available
- name-only matching remains as a fallback for minimal entries

A postal-code-only check was intentionally not used as a fallback when address is missing. Postal codes are not specific enough to uniquely identify a location, since multiple places can share the same postal code, especially within the same building, block, or area. Using postal code alone would increase false duplicate matches.

## Related Issues
Closes #142 (Dark Theme Adjustments)
Closes #147

## Notes
- Address similarity is case-insensitive for duplicate detection only
- `Address.equals(...)` and full `Location.equals(...)` remain unchanged for strict equality semantics