### PR TITLE
Proper check for duplicates in edit command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -105,6 +105,11 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_LOCATION);
         }
 
+        // changing existing location to another via identity fields (postal code, address)
+        if (model.hasMoreLocation(editedLocation)) {
+            throw new CommandException(MESSAGE_DUPLICATE_LOCATION);
+        }
+
         model.setLocation(locationToEdit, editedLocation);
         model.updateFilteredLocationList(PREDICATE_SHOW_ALL_LOCATIONS);
         return new CommandResult(String.format(MESSAGE_EDIT_LOCATION_SUCCESS, Messages.format(editedLocation)));

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -114,6 +114,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if two or more location with the same identity as {@code location} exists in the address book.
+     */
+    public boolean hasMoreLocation(Location location) {
+        requireNonNull(location);
+        return locations.containsMore(location);
+    }
+
+    /**
      * Adds a location to the address book.
      * The location must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -171,6 +171,8 @@ public interface Model {
      */
     boolean hasLocation(Location location);
 
+    boolean hasMoreLocation(Location location);
+
     /**
      * Deletes the given location.
      * The location must exist in the address book.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -243,6 +243,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasMoreLocation(Location location) {
+        requireNonNull(location);
+        return addressBook.hasMoreLocation(location);
+    }
+
+    @Override
     public void deleteLocation(Location target) {
         addressBook.removeLocation(target);
         hasUnsavedAddressBookChanges = true;

--- a/src/main/java/seedu/address/model/location/UniqueLocationList.java
+++ b/src/main/java/seedu/address/model/location/UniqueLocationList.java
@@ -37,6 +37,17 @@ public class UniqueLocationList implements Iterable<Location> {
     }
 
     /**
+     * Returns true if the list contains two or more equivalent location as the given argument.
+     */
+    public boolean containsMore(Location toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream()
+                .filter(toCheck::isSameLocation)
+                .count() >= 2;
+    }
+
+
+    /**
      * Adds a location to the list.
      * The location must not already exist in the list.
      */

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -188,6 +188,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasMoreLocation(Location location) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deleteLocation(Location target) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
## Bug
Edit command would previously allow any trancation that was either changing an existing location, or if the new location had no duplicates.

```
if (!locationToEdit.isSameLocation(editedLocation) && model.hasLocation(editedLocation)) {
            throw new CommandException(MESSAGE_DUPLICATE_LOCATION);
        }
```

this allowed duplicates to be created by changing an existing location WHILE creating dupes.

## Fix
added additional check 
```
if (model.hasMoreLocation(editedLocation)) {
            throw new CommandException(MESSAGE_DUPLICATE_LOCATION);
        }
```
That would throw exception if given that you are editing an existing location, and there are two or more duplicate locations in the current list.

closes #237