### PR TITLE
Relax tag restrictions

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -118,6 +118,14 @@ Can start with `+` and may include spaces or hyphens between digits (e.g. `91231
 
 Must contain at least one digit and be no longer than 15 characters.
 
+### Tag Formats
+
+May include alphanumeric characters, spaces or hyphens.
+
+Must contain at least one alphanumeric character.
+
+All Tag inputs are translated and stored as lowercase.
+
 ### Date Formats
 
 AddressMe even accepts a large range of date inputs so you can type dates flexibly.

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,8 +9,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should contain at least one alphanumeric character."
+            + "It can have alphanumeric characters, spaces and hyphens.";
+    public static final String VALIDATION_REGEX = "^(?=.*[A-Za-z0-9])[A-Za-z0-9\\- ]+$";
 
     public final String tagName;
 
@@ -22,7 +23,7 @@ public class Tag {
     public Tag(String tagName) {
         requireNonNull(tagName);
         checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
-        this.tagName = tagName;
+        this.tagName = tagName.toLowerCase();
     }
 
     /**


### PR DESCRIPTION
This PR:
Allows Tags to contain spaces and hyphens (but still must contain at least one alphanumeric)
closes #239 

Converts all tags to lowercase when storing, prevents capitalization issues
closes #258 

Documents the tag constraints in UG
closes #246
