### PR TITLE
Fix Use Case Issues in DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -532,21 +532,20 @@ Use case ends.
 
 **Extensions**
 
-**2a. The alias violates validation constraints.**
+* 2a. The alias violates validation constraints.
 (e.g. contains illegal characters, matches a reserved keyword, or conflicts with an existing alias)
-2a1. System rejects the request and shows an appropriate error message.
-Use case ends.
+  * 2a1. System rejects the request and shows an appropriate error message.
+  Use case ends.
 
 
-**2b. The referenced command word is invalid.**
-(e.g. command does not exist or is not eligible for aliasing)
-2b1. System shows an error message indicating that the command is invalid.
-Use case ends.
+* 2b. The referenced command word is invalid.
+  * 2b1. System shows an error message indicating that the command is invalid.
+  Use case ends.
 
 
-**3a. Saving the shortcut fails due to a storage I/O error.**
-3a1. System shows an error message and does not persist the shortcut.
-Use case ends.
+* 3a. Saving the shortcut fails due to a storage I/O error.
+  * 3a1. System shows an error message and does not persist the shortcut.
+  Use case ends.
 
 ---
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -628,7 +628,6 @@ Use case ends.
 2. System closes the application.
 Use case ends.
 
-**Extensions**
 
 ---
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -660,11 +660,6 @@ Use case resumes at step 2.
 Use case resumes at step 2.
 
 
-* 5a. An error occurs during deletion.
-* 5a1. System informs the user that the deletion failed.
-Use case ends.
-
-
 * *a. At any time, the user cancels the delete operation.
 * *a1. System aborts the delete operation.
 Use case ends.

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -510,13 +510,13 @@ Use case ends.
 **Extensions**
 
 * 2a. The given details are invalid.
-* 2a1. System shows an error message, and if it can handle gracefully with incomplete data, will show the details it managed to add.
-Use case resumes at step 3.
+  * 2a1. System shows an error message, and if it can handle gracefully with incomplete data, will show the details it managed to add.
+  Use case resumes at step 3.
 
 
 * 2b. The given location name is invalid.
-* 2b1. System shows an error message and informs the user it is unable to add the entry.
-Use case ends.
+  * 2b1. System shows an error message and informs the user it is unable to add the entry.
+  Use case ends.
 
 ---
 
@@ -563,24 +563,26 @@ Use case ends.
 
 * 2a. The list is empty.
 Use case ends.
+
+
 * 3a. The given index is invalid (out of range or non-numeric).
-* 3a1. System shows an error message: "Invalid index. Please enter a valid location index."
-Use case resumes at step 2.
+  * 3a1. System shows an error message: "Invalid index. Please enter a valid location index."
+  Use case resumes at step 2.
 
 
 * 3b. The provided email format is invalid.
-* 3b1. System shows an error message regarding the invalid email.
-Use case resumes at step 2.
+  * 3b1. System shows an error message regarding the invalid email.
+  Use case resumes at step 2.
 
 
 * 3c. The provided phone number format is invalid.
-* 3c1. System shows an error message regarding the invalid phone number.
-Use case resumes at step 2.
+  * 3c1. System shows an error message regarding the invalid phone number.
+  Use case resumes at step 2.
 
 
 * 3d. The edited details result in a duplicate entry (it matches an existing entry's name + phone/email).
-* 3d1. System rejects the edit, leaves the original record unchanged, and shows an error message.
-Use case resumes at step 2.
+  * 3d1. System rejects the edit, leaves the original record unchanged, and shows an error message.
+  Use case resumes at step 2.
 
 ---
 
@@ -595,8 +597,8 @@ Use case ends.
 **Extensions**
 
 * 2a. The list is empty.
-* 2a1. System informs the user the list is empty.
-Use case ends.
+  * 2a1. System informs the user the list is empty.
+  Use case ends.
 
 ---
 
@@ -613,8 +615,8 @@ Use case ends.
 **Extensions**
 
 * 1a. The entered date is invalid.
-* 1a1. System informs the user of correct date and command format.
-  Use case ends.
+  * 1a1. System informs the user of correct date and command format.
+    Use case ends.
 
 ---
 
@@ -643,20 +645,20 @@ Use case ends.
 **Extensions**
 
 * 2a. The list of locations is empty.
-* 2a1. System informs the user that there are no locations to delete.
-Use case ends.
+  * 2a1. System informs the user that there are no locations to delete.
+  Use case ends.
 
 
 * 3a. At least one given index is invalid.
-* 3a1. System shows an error message.
-* 3a2. System lists the available locations again.
-Use case resumes at step 2.
+  * 3a1. System shows an error message.
+  * 3a2. System lists the available locations again.
+  Use case resumes at step 2.
 
 
 * 3b. Duplicate indices are provided (e.g., `delete 2 2`).
-* 3b1. System shows an error message.
-* 3b2. System lists the available locations again.
-Use case resumes at step 2.
+  * 3b1. System shows an error message.
+  * 3b2. System lists the available locations again.
+  Use case resumes at step 2.
 
 
 * *a. At any time, the user cancels the delete operation.
@@ -678,8 +680,8 @@ Use case ends.
 **Extensions**
 
 * 2a. There is no stored undo state.
-* 2a1. System shows an error message.
-Use case ends.
+  * 2a1. System shows an error message.
+  Use case ends.
 
 ---
 
@@ -696,8 +698,8 @@ Use case ends.
 **Extensions**
 
 * 2a. There is no stored redo state.
-* 2a1. System shows an error message.
-Use case ends.
+  * 2a1. System shows an error message.
+  Use case ends.
 
 ### Non-Functional Requirements
 


### PR DESCRIPTION
## Issue 1
Delete Use Case contains broken extension referencing non-existent MSS step

I fixed it by removing that extension entirely as it served very little purpose and the previous 2 extensions addressed the same thing with more details.

Fixes #212, 
Fixes #233

## Issue 2
"Shortcut" Use case merges sub-extensions into same line as extension

Formatting issue. Just fixed formatting to make it consistent.

Fixes #216,
Fixes #219

## Issue 3
Use cases extensions have no indentation levels

Fixed by adding indentations, following course website formatting.

Fixes #224

## Issue 4
Extension heading in Use Case when there are no extensions

Fixed by removing extension header

Fixes #247