### PR TITLE
Delete Note Now Stays Deleted on Relaunch

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -344,6 +344,7 @@ public class ModelManager implements Model {
     public void removeNote(VisitDate date) {
         requireNonNull(date);
         addressBook.removeNote(date);
+        hasUnsavedAddressBookChanges = true;
 
         // update UI if needed
         if (currentPlannedDate != null && date.isOn(currentPlannedDate)) {

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -236,6 +236,23 @@ public class LogicManagerTest {
     }
 
     @Test
+    public void execute_deleteNote_savesAddressBook() throws Exception {
+        CountingStorageManager storage = createCountingStorage();
+        logic = new LogicManager(model, storage);
+
+        model.setNote(VisitDate.of("2026-03-24"), new NoteContent("Test Note"));
+        model.markAddressBookSaved();
+
+        assertCommandSuccess("note d-/2026-03-24",
+                String.format(DeleteNoteCommand.MESSAGE_SUCCESS, VisitDate.of("2026-03-24")),
+                new ModelManager());
+
+        assertEquals(1, storage.addressBookSaveCount);
+        assertEquals(0, storage.shortcutSaveCount);
+        assertEquals(0, storage.userPrefsSaveCount);
+    }
+
+    @Test
     public void getMethods_success() {
         assertEquals(model.getAddressBook(), logic.getAddressBook());
         assertEquals(model.getAddressBookFilePath(), logic.getAddressBookFilePath());

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -351,6 +351,19 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void removeNote_existingNote_marksAddressBookDirty() throws Exception {
+        VisitDate date = VisitDate.of("2026-03-24");
+        NoteContent note = new NoteContent("Involves lots of walking. Bring extra water bottles.");
+
+        modelManager.setNote(date, note);
+        modelManager.markAddressBookSaved();
+
+        modelManager.removeNote(date);
+
+        assertTrue(modelManager.hasUnsavedAddressBookChanges());
+    }
+
+    @Test
     public void removeNote_nullDate_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> modelManager.removeNote(null));
     }


### PR DESCRIPTION
## Description
Marks the address book dirty when `removeNote` deletes a note, so `LogicManager` persists note deletions to storage.

Fixes #222

You can try the example in the given issue before and after the fix for manual testing.