### PR TITLE
Ambiguate date error messages to account for both invalid dates and invalid formats

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -140,7 +140,8 @@ AddressMe even accepts a large range of date inputs so you can type dates flexib
 | **D/M/YYYY**     | **D-M-YYYY**     |
 | **D/M/YY**       | **D-M-YY**       |
 
-- With **day** and **month** (no **year**): AddressMe picks the next occurrence of that date.
+- With **day** and **month** (no **year**): AddressMe picks the next occurrence of that date. For edge cases like 
+29 Feb, if it does not exist in the year, AddressMe gracefully corrects it to 28 Feb.
 
 | **With slashes** | **With hyphens** |
 |------------------|------------------|

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -17,7 +17,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_DATE_COMMAND_FORMAT = "Invalid command or date format! \n%1$s";
+    public static final String MESSAGE_INVALID_DATE_COMMAND_FORMAT = "%1$s is not a valid date! \n%2$s";
     public static final String MESSAGE_INVALID_LOCATION_DISPLAYED_INDEX = "The location index provided is invalid";
     public static final String MESSAGE_LOCATIONS_LISTED_OVERVIEW = "%1$d matching locations found!";
     public static final String MESSAGE_DUPLICATE_FIELDS =

--- a/src/main/java/seedu/address/logic/commands/PlanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PlanCommand.java
@@ -21,7 +21,7 @@ public class PlanCommand extends Command {
             + "Parameters: [DATE]\n"
             + "Example: " + COMMAND_WORD + " 13/3/26";
 
-    public static final String MESSAGE_DATE_USAGE =  "Try these formats with a valid date:\n"
+    public static final String MESSAGE_DATE_USAGE = "Try these formats with a valid date:\n"
             + "yyyy-MM-dd, yyyy/MM/dd, d-M-yyyy, d/M/yyyy,\n"
             + "d-M-yy, d/M/yy, d-M, d/M, day of the week (e.g. Thu or Thursday).";
 

--- a/src/main/java/seedu/address/logic/commands/PlanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PlanCommand.java
@@ -18,8 +18,12 @@ public class PlanCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Displays the all the locations listed for a "
             + "valid date in the right window.\n"
-            + "Parameters: DATE\n"
+            + "Parameters: [DATE]\n"
             + "Example: " + COMMAND_WORD + " 13/3/26";
+
+    public static final String MESSAGE_DATE_USAGE =  "Try these formats with a valid date:\n"
+            + "yyyy-MM-dd, yyyy/MM/dd, d-M-yyyy, d/M/yyyy,\n"
+            + "d-M-yy, d/M/yy, d-M, d/M, day of the week (e.g. Thu or Thursday).";
 
     public static final String MESSAGE_DISPLAY_SUCCESS = "Displaying date: %1$s";
 

--- a/src/main/java/seedu/address/logic/parser/DateParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateParser.java
@@ -19,7 +19,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
  * Represents a static utility class that can convert between Strings and LocalDate, MonthDay and DayOfWeek
  */
 public class DateParser {
-    public static final String MESSAGE_WRONG_DATE_FORMAT = "Not a valid date! Try using these formats:\n"
+    public static final String MESSAGE_WRONG_DATE_FORMAT = "Invalid date! Try using these formats:\n"
             + "yyyy-MM-dd, yyyy/MM/dd, d-M-yyyy, d/M/yyyy,\n"
             + "d-M-yy, d/M/yy, d-M, d/M, day of the week (e.g. Thu or Thursday).";
 

--- a/src/main/java/seedu/address/logic/parser/PlanCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PlanCommandParser.java
@@ -28,7 +28,7 @@ public class PlanCommandParser implements Parser<PlanCommand> {
             return new PlanCommand(date);
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(
-                    MESSAGE_INVALID_DATE_COMMAND_FORMAT, PlanCommand.MESSAGE_USAGE), ive);
+                    MESSAGE_INVALID_DATE_COMMAND_FORMAT, trimmedArgs, PlanCommand.MESSAGE_DATE_USAGE), ive);
         }
     }
 }

--- a/src/main/java/seedu/address/model/location/dates/VisitDate.java
+++ b/src/main/java/seedu/address/model/location/dates/VisitDate.java
@@ -18,8 +18,8 @@ public abstract class VisitDate {
             + " formats:\ne-d/M, e-d/M, every d/M to indicate it happening every year.\nevery Tuesday, e-fri as "
             + "examples of dates occurring every Tuesday or Friday.\nDates must be valid.";
     public static final String MESSAGE_CONSTRAINTS = DateParser.MESSAGE_WRONG_DATE_FORMAT
-            + "\nFor recurring dates, use the format e-[DATE], or every [DATE],\n"
-            + "where [DATE] is in day and month format or a day of the week";
+            + "\nFor recurring dates, use the format 'e-DATE', or 'every DATE',\n"
+            + "where DATE is in day and month format or a day of the week";
 
     private static final String RECURRING_DATE_REGEX = "^(every\\s+|e-).+";
     private static final String RECURRING_DATE_PREFIX_REGEX = "^(every\\s+|e-)";

--- a/src/main/java/seedu/address/model/location/dates/VisitDate.java
+++ b/src/main/java/seedu/address/model/location/dates/VisitDate.java
@@ -14,7 +14,7 @@ import seedu.address.logic.parser.DateParser;
 public abstract class VisitDate {
 
     public static final String MESSAGE_CONSTRAINTS_EMPTY = "The date cannot be empty!";
-    public static final String MESSAGE_CONSTRAINTS_RECURRING = "Recurring dates must be yearly or weekly. Try these"
+    public static final String MESSAGE_CONSTRAINTS_RECURRING = "Invalid recurring date! Try these"
             + " formats:\ne-d/M, e-d/M, every d/M to indicate it happening every year.\nevery Tuesday, e-fri as "
             + "examples of dates occurring every Tuesday or Friday.\nDates must be valid.";
     public static final String MESSAGE_CONSTRAINTS = DateParser.MESSAGE_WRONG_DATE_FORMAT


### PR DESCRIPTION
<img width="813" height="212" alt="image" src="https://github.com/user-attachments/assets/70abc7ce-f96f-44ac-95aa-3db5ce5bc99f" />
<img width="793" height="207" alt="image" src="https://github.com/user-attachments/assets/d17dc229-33d6-4a45-a59b-af425837d573" />

Error messages for date commands are made ambiguous enough that regardless of wrong formats or invalid dates, it appears that the message is specific enough to the error.

Due to how the DateParser is programmed (try every dateformat in order), the system only throws an exception at the end after it fails all formats. Thus, it is impossible to differentiate if it fails date validity or format validity. Thus ambiguity is the best alternative.

closes #221, closes #251