### PR TITLE
Fix location list refreshing after add and edit

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -12,7 +12,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTAL_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_ADD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_REMOVE;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_LOCATIONS;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -106,7 +106,6 @@ public class EditCommand extends Command {
         }
 
         model.setLocation(locationToEdit, editedLocation);
-        model.updateFilteredLocationList(PREDICATE_SHOW_ALL_LOCATIONS);
         return new CommandResult(String.format(MESSAGE_EDIT_LOCATION_SUCCESS, Messages.format(editedLocation)));
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -252,7 +252,6 @@ public class ModelManager implements Model {
     public void addLocation(Location location) {
         addressBook.addLocation(location);
         hasUnsavedAddressBookChanges = true;
-        updateFilteredLocationList(PREDICATE_SHOW_ALL_LOCATIONS);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -106,6 +106,7 @@ public class EditCommandTest {
                 new ShortcutMap());
         expectedModel.setLocation(model.getFilteredLocationList().get(0), editedLocation);
 
+        expectedModel.updateFilteredLocationList(Model.PREDICATE_HIDE_ALL_LOCATIONS);
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 


### PR DESCRIPTION
Simple fix by deleting lines that reset the Location list predicates.

fixes #196, fixes #197