### PR TITLE
Fix edit command parser to preserve invalid index parse errors

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -48,7 +48,14 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         Index index;
 
-        index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        String preamble = argMultimap.getPreamble().trim();
+        String[] preambleParts = preamble.split("\\s+");
+
+        if (preamble.isEmpty() || preambleParts.length != 1) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+        }
+
+        index = ParserUtil.parseIndex(preamble);
 
         argMultimap.verifyNoDuplicatePrefixesFor(
                 PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_POSTAL_CODE);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -48,11 +48,7 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         Index index;
 
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
-        }
+        index = ParserUtil.parseIndex(argMultimap.getPreamble());
 
         argMultimap.verifyNoDuplicatePrefixesFor(
                 PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_POSTAL_CODE);

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -73,10 +73,10 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5" + NAME_DESC_AMY, ParserUtil.MESSAGE_INVALID_INDEX);
 
         // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + NAME_DESC_AMY, ParserUtil.MESSAGE_INVALID_INDEX);
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);


### PR DESCRIPTION
Closes #203.

Fixes incorrect error handling in `EditCommandParser`.

### What changed
- Removed the catch block in `EditCommandParser` that was overriding index parse errors
- Added validation to ensure the preamble contains exactly one index

### Behavior changes
- `edit 0 n/Test` → now shows: `Index is not a non-zero unsigned integer.`
- `edit -1 n/Test` → same as above
- `edit abc n/Test` → same as above

- `edit` → still shows invalid command format
- `edit 1 2 3` → still shows invalid command format

### Why
Previously, inputs like `edit 0 n/Test` or `edit -1 n/Test` could be reported as invalid command format instead of surfacing the more specific invalid index error from `ParserUtil.parseIndex(...)`.

This PR only updates error handling for the `edit` command.

Scoped this PR only to `edit` to avoid changing multi-index parsing behavior in `delete`.