### PR TITLE
Make delete command output similar to edit and update UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -37,7 +37,7 @@ AddressMe is the app for you!
 ---
 
 * Table of Contents
-  {:toc}
+{:toc}
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -323,7 +323,7 @@ Format:
 `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/POSTAL_CODE] [d/DATE]… [d+/DATE]… [d-/DATE]… [t/TAG]… [t+/TAG]… [t-/TAG]…`
 
 * Edits the location at the specified `INDEX`. The index refers to the index number shown in the displayed location
-  list. The index **must be a positive number** 1, 2, 3, ...
+  list. The index **must be a positive number** (e.g. 1, 2, 3, ...)
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input.
 * To clear a field, provide the prefix without a value (e.g. `p/` to clear phone).
@@ -355,10 +355,11 @@ Format:
 <div style="page-break-after: always;"></div>
 ### `delete` - Deleting a location
 
-Removes one or more locations from your address book, keeping it clean and relevant throughout your journey.<br>
-Accepts multiple unique index numbers in a single command.
+Removes one or more locations from your address book, keeping it clean and relevant throughout your journey.
 
 Format: `delete INDEX [MORE_INDEXES]...`
+
+* Accepts multiple unique index numbers in a single command. All indices **must be positive numbers** (e.g. 1, 2, 3, ...)
 
 <div markdown="block" class="alert alert-primary">:bulb: **Tip:** Deleted anything by accident? Try the `undo` command listed [here](#undo---reverting-the-last-change)!
 </div>

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -46,6 +46,16 @@ public class Messages {
     }
 
     /**
+     * Returns an error message indicating the valid displayed index range for multiple indices.
+     */
+    public static String getInvalidLocationDisplayedIndexesMessage(int locationCount) {
+        if (locationCount <= 0) {
+            return "Invalid indices. There are no entries in the current list.";
+        }
+        return String.format("At least one of the indices is invalid. Valid index range is 1 to %d.", locationCount);
+    }
+
+    /**
      * Formats the {@code location} for display to the user.
      */
     public static String format(Location location) {

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -31,6 +31,8 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_DELETE_LOCATION_SUCCESS = "Deleted Location: %1$s";
     public static final String MESSAGE_DELETE_LOCATIONS_SUCCESS = "Deleted Locations:\n%1$s";
     public static final String MESSAGE_DUPLICATE_INDEX = "Duplicate indices are not allowed.";
+    public static final String MESSAGE_INVALID_INDEXES = "At least one of the indices is not a non-zero unsigned "
+            + "integer.";
 
     private final List<Index> targetIndexes;
 
@@ -63,7 +65,10 @@ public class DeleteCommand extends Command {
             }
 
             if (targetIndex.getZeroBased() >= lastShownList.size()) {
-                throw new CommandException(Messages.getInvalidLocationDisplayedIndexMessage(lastShownList.size()));
+                String message = targetIndexes.size() > 1
+                        ? Messages.getInvalidLocationDisplayedIndexesMessage(lastShownList.size())
+                        : Messages.getInvalidLocationDisplayedIndexMessage(lastShownList.size());
+                throw new CommandException(message);
             }
 
             locationsToDelete.add(lastShownList.get(targetIndex.getZeroBased()));

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -20,20 +20,28 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
-        try {
-            String trimmedArgs = args.trim();
-            String[] indexTokens = trimmedArgs.split("\\s+");
+        String trimmedArgs = args.trim();
+        String[] indexTokens = trimmedArgs.split("\\s+");
 
-            List<Index> indexes = new ArrayList<>();
-            for (String indexToken : indexTokens) {
-                indexes.add(ParserUtil.parseIndex(indexToken));
-            }
-
-            return new DeleteCommand(indexes);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
+
+        List<Index> indexes = new ArrayList<>();
+        for (String indexToken : indexTokens) {
+            Index index;
+            try {
+                index = ParserUtil.parseIndex(indexToken);
+            } catch (ParseException pe) {
+                if (indexTokens.length > 1) {
+                    throw new ParseException(DeleteCommand.MESSAGE_INVALID_INDEXES, pe);
+                }
+                throw pe;
+            }
+            indexes.add(index);
+        }
+
+        return new DeleteCommand(indexes);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -27,6 +27,12 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
 
+        for (String indexToken : indexTokens) {
+            if (!isInteger(indexToken)) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            }
+        }
+
         List<Index> indexes = new ArrayList<>();
         for (String indexToken : indexTokens) {
             Index index;
@@ -42,6 +48,10 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         }
 
         return new DeleteCommand(indexes);
+    }
+
+    private static boolean isInteger(String token) {
+        return token.matches("[+-]?\\d+");
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -55,6 +55,15 @@ public class DeleteCommandTest {
     }
 
     @Test
+    public void execute_invalidMultipleIndexesUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredLocationList().size() + 1);
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(INDEX_FIRST_LOCATION, outOfBoundIndex));
+
+        assertCommandFailure(deleteCommand, model,
+                Messages.getInvalidLocationDisplayedIndexesMessage(model.getFilteredLocationList().size()));
+    }
+
+    @Test
     public void execute_validIndexesUnfilteredList_success() {
         Location firstLocationToDelete = model.getFilteredLocationList().get(INDEX_FIRST_LOCATION.getZeroBased());
         Location thirdLocationToDelete = model.getFilteredLocationList().get(INDEX_THIRD_LOCATION.getZeroBased());
@@ -105,6 +114,20 @@ public class DeleteCommandTest {
 
         assertCommandFailure(deleteCommand, model,
                 Messages.getInvalidLocationDisplayedIndexMessage(model.getFilteredLocationList().size()));
+    }
+
+    @Test
+    public void execute_invalidMultipleIndexesFilteredList_throwsCommandException() {
+        showLocationAtIndex(model, INDEX_FIRST_LOCATION);
+
+        Index outOfBoundIndex = INDEX_SECOND_LOCATION;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getLocationList().size());
+
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(INDEX_FIRST_LOCATION, outOfBoundIndex));
+
+        assertCommandFailure(deleteCommand, model,
+                Messages.getInvalidLocationDisplayedIndexesMessage(model.getFilteredLocationList().size()));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -14,10 +14,8 @@ import seedu.address.logic.commands.DeleteCommand;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the DeleteCommand code. For example, inputs "1" and "1 abc" take the
- * same path through the DeleteCommand, and therefore we test only one of them.
- * The path variation for those two cases occur inside the ParserUtil, and
- * therefore should be covered by the ParserUtilTest.
+ * outside the DeleteCommand code. The path variations inside ParserUtil should be
+ * covered by the ParserUtilTest.
  */
 public class DeleteCommandParserTest {
 
@@ -36,15 +34,21 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "0", ParserUtil.MESSAGE_INVALID_INDEX);
         assertParseFailure(parser, "-5", ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "/n", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "  ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidMultipleArgs_throwsParseException() {
         assertParseFailure(parser, "1 -1", DeleteCommand.MESSAGE_INVALID_INDEXES);
-        assertParseFailure(parser, "a 1", DeleteCommand.MESSAGE_INVALID_INDEXES);
+        assertParseFailure(parser, "a 1", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "1 /n", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "1 -1 /a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "1 -1 -a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -36,7 +36,15 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "0", ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "-5", ParserUtil.MESSAGE_INVALID_INDEX);
         assertParseFailure(parser, "  ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidMultipleArgs_throwsParseException() {
+        assertParseFailure(parser, "1 -1", DeleteCommand.MESSAGE_INVALID_INDEXES);
+        assertParseFailure(parser, "a 1", DeleteCommand.MESSAGE_INVALID_INDEXES);
     }
 }


### PR DESCRIPTION
# Issue 1

Related to PR #276, but this PR targets the delete command.

- When delete is given a single invalid index, it uses the same singular error message as edit.
- When delete is given multiple indices and at least one is invalid, the error message uses plural wording.
  - This applies to both invalid index formats, such as `delete 1 -1`, and out-of-range displayed indices, such as `delete 1 999`.

This makes delete command errors clearer while preserving the existing edit command behavior.

## Manual Testing

1. Enter `delete -1`.

   Expected: `Index is not a non-zero unsigned integer.`

2. Enter `delete 0`.

   Expected: `Index is not a non-zero unsigned integer.`

3. Enter `delete 1 -1`.

   Expected: `At least one of the indices is not a non-zero unsigned integer.`

4. Enter `delete 1 0`.

   Expected: `At least one of the indices is not a non-zero unsigned integer.`

5. Enter `delete 999`, where `999` is outside the displayed list range.

   Expected: `Invalid index. Valid index range is 1 to N.`

6. Enter `delete 1 999`, where `1` is valid and `999` is outside the displayed list range.

   Expected: `At least one of the indices is invalid. Valid index range is 1 to N.`

7. Enter `delete 1 2`, where both indices exist in the displayed list.

   Expected: The two selected locations are deleted successfully.
   
   
# Issue 2
TOC of UG went missing. Fixed it.
Fixes #280 