### PR TITLE
Fix single index edit command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -68,6 +68,7 @@ public class EditCommand extends Command {
             + PREFIX_DATE_REMOVE + "2026-02-01";
 
     public static final String MESSAGE_EDIT_LOCATION_SUCCESS = "Edited Location: %1$s";
+    public static final String MESSAGE_EMPTY_INDEX = "Index cannot be empty.";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_LOCATION = "This location already exists in the address book.";
     public static final String MESSAGE_CANNOT_OVERRIDE_AND_MODIFY_TAGS = "Cannot combine t/ with t+/ or t-/";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -68,7 +68,6 @@ public class EditCommand extends Command {
             + PREFIX_DATE_REMOVE + "2026-02-01";
 
     public static final String MESSAGE_EDIT_LOCATION_SUCCESS = "Edited Location: %1$s";
-    public static final String MESSAGE_EMPTY_INDEX = "Index cannot be empty.";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_LOCATION = "This location already exists in the address book.";
     public static final String MESSAGE_CANNOT_OVERRIDE_AND_MODIFY_TAGS = "Cannot combine t/ with t+/ or t-/";

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -50,8 +50,9 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         String preamble = argMultimap.getPreamble().trim();
         String[] preambleParts = preamble.split("\\s+");
+        boolean isBadIndex = preamble.isEmpty() || preambleParts.length != 1 || !preamble.matches("-?\\d+");
 
-        if (preamble.isEmpty() || preambleParts.length != 1) {
+        if (isBadIndex) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
 

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -83,6 +83,15 @@ public class EditCommandParserTest {
 
         // invalid prefix being parsed as preamble
         assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+
+        // preamble size one but bad form
+        assertParseFailure(parser, "/n n/test name", MESSAGE_INVALID_FORMAT);
+
+        // preamble size one but bad form (generic string)
+        assertParseFailure(parser, "abc n/test name", MESSAGE_INVALID_FORMAT);
+
+        // preamble size one but bad form
+        assertParseFailure(parser, "-1 n/test name", ParserUtil.MESSAGE_INVALID_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -90,7 +90,7 @@ public class EditCommandParserTest {
         // preamble size one but bad form (generic string)
         assertParseFailure(parser, "abc n/test name", MESSAGE_INVALID_FORMAT);
 
-        // preamble size one but bad form
+        // preamble size one, an integer but not a non-zero unsigned integer
         assertParseFailure(parser, "-1 n/test name", ParserUtil.MESSAGE_INVALID_INDEX);
     }
 


### PR DESCRIPTION
Update `EditCommandParser` to surface specific invalid index errors for integers (e.g., `0`, `-1`) while returning generic invalid format for non-integer single-size strings (e.g. `abc`, `/n`).

Closes #281